### PR TITLE
reflect rename of repo from python-bioimage-io to core-bioimage-io-python

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# python-bioimage-io core
+# core-bioimage-io-python
 
 Python specific core utilities for working with the BioimageIO model zoo.
 
@@ -57,7 +57,7 @@ Run prediction:
 bioimageio predict -m <MODEL> -i <INPUT> -o <OUTPUT>
 ```
 
-This is subject to change, see https://github.com/bioimage-io/python-bioimage-io/issues/87.
+This is subject to change, see https://github.com/bioimage-io/core-bioimage-io-python/issues/87.
 
 
 ## Running network predictions:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set setup_py_data = load_setup_py_data() %}
 
 package:
-  name: python-bioimage-io
+  name: core-bioimage-io
   version: {{ setup_py_data['version'] }}
 
 source:
@@ -48,11 +48,11 @@ test:
 
 
 about:
-  home: https://github.com/bioimage-io/python-bioimage-io
+  home: https://github.com/bioimage-io/core-bioimage-io-python
   license: MIT
   license_family: MIT
   license_file: LICENSE
   summary: 'Tools for running BioimageIO compliant neural networks in Python.'
 
-  doc_url: https://github.com/bioimage-io/python-bioimage-io
-  dev_url: https://github.com/bioimage-io/python-bioimage-io
+  doc_url: https://github.com/bioimage-io/core-bioimage-io-python
+  dev_url: https://github.com/bioimage-io/core-bioimage-io-python

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     description="Python functionality for the bioimage model zoo",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/bioimage-io/python-bioimage-io",
+    url="https://github.com/bioimage-io/core-bioimage-io-python",
     author="Bioimage Team",
     classifiers=[  # Optional
         "Development Status :: 3 - Alpha",
@@ -35,8 +35,8 @@ setup(
         "onnx": ["onnxruntime"],
     },
     project_urls={  # Optional
-        "Bug Reports": "https://github.com/bioimage-io/python-bioimage-io/issues",
-        "Source": "https://github.com/bioimage-io/python-bioimage-io",
+        "Bug Reports": "https://github.com/bioimage-io/core-bioimage-io-python/issues",
+        "Source": "https://github.com/bioimage-io/core-bioimage-io-python",
     },
     entry_points={"console_scripts": ["bioimageio = bioimageio.core.__main__:app"]},
 )


### PR DESCRIPTION
as discussed in #101, the package was renamed to `core-bioimage-io-python`.

I did a quick replace to reflect this in the files of this repo.

The pip package name is unchanged (`bioimage-core`), I think that's fine.