### PR TITLE
[conda] rename package in conda recipe

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set setup_py_data = load_setup_py_data() %}
 
 package:
-  name: core-bioimage-io
+  name: bioimageio.core
   version: {{ setup_py_data['version'] }}
 
 source:
@@ -10,6 +10,10 @@ source:
 build:
   noarch: python
   number: 0
+  entry_points:
+    {% for ep in setup_py_data['entry_points']['console_scripts'] %}
+    - {{ ep }}
+    {% endfor %}
   script: "{{ PYTHON }} -m pip install --no-deps --ignore-installed ."
 
 requirements:
@@ -18,6 +22,8 @@ requirements:
     - pip
   run:
     - python >=3.7
+    - tqdm
+    - typer
     {% for dep in setup_py_data['install_requires'] %}
     - {{ dep.lower() }}
     {% endfor %}


### PR DESCRIPTION
Also adds , `typer`, `tqdm` as deps to conda-package to make the cli work (also added that to the recipe).

For the conda package it would be preferable to get a full functioning version.
I guess that's nothing we want to change in setup.py because of runability in
jypterlite.

Just to make sure the conda-forge one (https://github.com/conda-forge/staged-recipes/pull/16283) and this recipe are comparable/in sync.