### PR TITLE
accept URLs in test-model command

### DIFF
--- a/bioimageio/core/__main__.py
+++ b/bioimageio/core/__main__.py
@@ -46,8 +46,8 @@ package.__doc__ = commands.package.__doc__
 # https://github.com/tiangolo/typer/issues/182
 @app.command()
 def test_model(
-    model_rdf: Path = typer.Argument(
-        ..., help="Path to the model resource description file (rdf.yaml) or zipped model."
+    model_rdf: str = typer.Argument(
+        ..., help="Path or URL to the model resource description file (rdf.yaml) or zipped model."
     ),
     weight_format: Optional[str] = typer.Argument(None, help="The weight format to use."),
     devices: Optional[List[str]] = typer.Argument(None, help="Devices for running the model."),

--- a/bioimageio/core/prediction.py
+++ b/bioimageio/core/prediction.py
@@ -481,7 +481,6 @@ def test_model(model_rdf: Union[URI, Path, str], weight_format=None, devices=Non
 
     Returns True if the test passes, otherwise returns False and issues a warning.
     """
-    print(model_rdf, Path(model_rdf).exists())
     model = load_resource_description(model_rdf)
     assert isinstance(model, Model)
     prediction_pipeline = create_prediction_pipeline(


### PR DESCRIPTION
previously input was always cast to pathlib.Path which does not work for urls.