### PR TITLE
Add test_resource

### DIFF
--- a/bioimageio/core/prediction.py
+++ b/bioimageio/core/prediction.py
@@ -4,22 +4,29 @@ import warnings
 from copy import deepcopy
 from itertools import product
 from pathlib import Path
-from typing import Dict, List, OrderedDict, Sequence, Tuple, Union
+from typing import Dict, List, Optional, OrderedDict, Sequence, Tuple, Union
 
 import imageio
 import numpy as np
 import xarray as xr
-
-from bioimageio.core import load_resource_description
-from bioimageio.core.resource_io.nodes import InputTensor, Model, OutputTensor
-from bioimageio.core.prediction_pipeline import PredictionPipeline, create_prediction_pipeline
 from tqdm import tqdm
 
+from bioimageio.core import load_resource_description
+from bioimageio.core.prediction_pipeline import PredictionPipeline, create_prediction_pipeline
 
 #
 # utility functions for prediction
 #
-from bioimageio.core.resource_io.nodes import ImplicitOutputShape, URI
+from bioimageio.core.resource_io.nodes import (
+    ImplicitOutputShape,
+    InputTensor,
+    Model,
+    OutputTensor,
+    ResourceDescription,
+    URI,
+)
+from bioimageio.spec.model.raw_nodes import WeightsFormat
+from bioimageio.spec.shared.raw_nodes import ResourceDescription as RawResourceDescription
 
 
 def require_axes(im, axes):
@@ -476,30 +483,59 @@ def predict_images(
         _predict_sample(prediction_pipeline, inp, outp, padding, tiling)
 
 
-def test_model(model_rdf: Union[URI, Path, str], weight_format=None, devices=None, decimal=4):
+def test_model(
+    model_rdf: Union[URI, Path, str],
+    weight_format: Optional[WeightsFormat] = None,
+    devices: Optional[List[str]] = None,
+    decimal: int = 4,
+) -> bool:
     """Test whether the test output(s) of a model can be reproduced.
 
     Returns True if the test passes, otherwise returns False and issues a warning.
     """
     model = load_resource_description(model_rdf)
     assert isinstance(model, Model)
-    prediction_pipeline = create_prediction_pipeline(
-        bioimageio_model=model, devices=devices, weight_format=weight_format
-    )
-    inputs = [np.load(str(in_path)) for in_path in model.test_inputs]
-    results = predict(prediction_pipeline, inputs)
-    if isinstance(results, (np.ndarray, xr.DataArray)):
-        results = [results]
-
-    expected = [np.load(str(out_path)) for out_path in model.test_outputs]
-    if len(results) != len(expected):
-        warnings.warn(f"Number of outputs and number of expected outputs disagree: {len(results)} != {len(expected)}")
+    summary = test_resource(model, weight_format=weight_format, devices=devices, decimal=decimal)
+    if summary["error"] is None:
+        return True
+    else:
+        warnings.warn(summary["error"])
         return False
 
-    for res, exp in zip(results, expected):
-        try:
-            np.testing.assert_array_almost_equal(res, exp, decimal=decimal)
-        except AssertionError as e:
-            warnings.warn(f"Output and expected output disagree:\n {e}")
-            return False
-    return True
+
+def test_resource(
+    model_rdf: Union[RawResourceDescription, ResourceDescription, URI, Path, str],
+    *,
+    weight_format: Optional[WeightsFormat] = None,
+    devices: Optional[List[str]] = None,
+    decimal: int = 4,
+):
+    """Test RDF dynamically
+
+    Returns summary with "error", keys
+    """
+    model = load_resource_description(model_rdf)
+
+    error: Optional[str] = None
+    if isinstance(model, Model):
+        prediction_pipeline = create_prediction_pipeline(
+            bioimageio_model=model, devices=devices, weight_format=weight_format
+        )
+        inputs = [np.load(str(in_path)) for in_path in model.test_inputs]
+        results = predict(prediction_pipeline, inputs)
+        if isinstance(results, (np.ndarray, xr.DataArray)):
+            results = [results]
+
+        expected = [np.load(str(out_path)) for out_path in model.test_outputs]
+        if len(results) != len(expected):
+            error = f"Number of outputs and number of expected outputs disagree: {len(results)} != {len(expected)}"
+        else:
+            for res, exp in zip(results, expected):
+                try:
+                    np.testing.assert_array_almost_equal(res, exp, decimal=decimal)
+                except AssertionError as e:
+                    error = f"Output and expected output disagree:\n {e}"
+
+    # todo: add tests for non-model resources
+
+    return {"error": error}

--- a/bioimageio/core/prediction.py
+++ b/bioimageio/core/prediction.py
@@ -512,7 +512,7 @@ def test_resource(
 ):
     """Test RDF dynamically
 
-    Returns summary with "error", keys
+    Returns summary dict with "error" key; summary["error"] is None if no errors were encountered.
     """
     model = load_resource_description(model_rdf)
 

--- a/bioimageio/core/resource_io/io_.py
+++ b/bioimageio/core/resource_io/io_.py
@@ -91,7 +91,7 @@ def _replace_relative_paths_for_remote_source(
 
 
 def load_raw_resource_description(
-    source: Union[dict, os.PathLike, IO, str, bytes, raw_nodes.URI]
+    source: Union[dict, os.PathLike, IO, str, bytes, raw_nodes.URI, RawResourceDescription]
 ) -> RawResourceDescription:
     """load a raw python representation from a BioImage.IO resource description file (RDF).
     Use `load_resource_description` for a more convenient representation.
@@ -102,13 +102,16 @@ def load_raw_resource_description(
     Returns:
         raw BioImage.IO resource
     """
+    if isinstance(source, RawResourceDescription):
+        return source
+
     raw_rd = spec.load_raw_resource_description(source, update_to_current_format=True)
     raw_rd = _replace_relative_paths_for_remote_source(raw_rd, raw_rd.root_path)
     return raw_rd
 
 
 def load_resource_description(
-    source: Union[RawResourceDescription, os.PathLike, str, dict, raw_nodes.URI],
+    source: Union[RawResourceDescription, ResourceDescription, os.PathLike, str, dict, raw_nodes.URI],
     *,
     weights_priority_order: Optional[Sequence[str]] = None,  # model only
 ) -> ResourceDescription:
@@ -123,6 +126,9 @@ def load_resource_description(
         BioImage.IO resource
     """
     source = deepcopy(source)
+    if isinstance(source, ResourceDescription):
+        return source
+
     raw_rd = load_raw_resource_description(source)
 
     if weights_priority_order is not None:


### PR DESCRIPTION
an extended version of `test_model`.
No checks are performed for non-model resources yet (but they won't raise an exception)

Todo:
 - [ ] decide wether `test_model` shoulda also return a summary dict instead of a boolean...