### PR TITLE
bump version

### DIFF
--- a/bioimageio/core/VERSION
+++ b/bioimageio/core/VERSION
@@ -1,3 +1,3 @@
 {
-    "version": "0.4.2.post0"
+    "version": "0.4.3"
 }


### PR DESCRIPTION
I suppose adding a new cli command `test-resource` justifies a patch version bump... (also needed for the collection CI)