### PR TITLE
Add --version option

### DIFF
--- a/bioimageio/core/__main__.py
+++ b/bioimageio/core/__main__.py
@@ -47,7 +47,10 @@ package.__doc__ = commands.package.__doc__
 
 # if we want to use something like "choice" for the weight formats, we need to use an enum, see:
 # https://github.com/tiangolo/typer/issues/182
-WeightFormatEnum = enum.Enum("WeightFormatEnum", get_args(WeightsFormat))
+WeightFormatEnum = enum.Enum("WeightFormatEnum", {wf: wf for wf in get_args(WeightsFormat)})
+# Enum with in values does not work with click.Choice: https://github.com/pallets/click/issues/784
+# so a simple Enum with auto int values is not an option:
+# WeightFormatEnum = enum.Enum("WeightFormatEnum", get_args(WeightsFormat))
 
 
 @app.command()

--- a/bioimageio/core/__main__.py
+++ b/bioimageio/core/__main__.py
@@ -9,7 +9,7 @@ from typing import List, Optional
 import typer
 
 from bioimageio.core import __version__, prediction, commands, resource_tests
-from bioimageio.spec.__main__ import app
+from bioimageio.spec.__main__ import app, help_version as help_version_spec
 from bioimageio.spec.model.raw_nodes import WeightsFormat
 
 try:
@@ -21,6 +21,18 @@ try:
     from bioimageio.core.weight_converter import torch as torch_converter
 except ImportError:
     torch_converter = None
+
+
+# extend help/version string by core version
+help_version_core = f"bioimageio.core {__version__}"
+help_version = f"{help_version_spec}\n{help_version_core}"
+# prevent rewrapping with \b\n: https://click.palletsprojects.com/en/7.x/documentation/#preventing-rewrapping
+app.info.help = "\b\n" + help_version
+
+
+@app.callback()
+def callback():
+    typer.echo(help_version)
 
 
 @app.command()
@@ -222,5 +234,4 @@ if torch_converter is not None:
 
 
 if __name__ == "__main__":
-    print(f"bioimageio.core package version {__version__}")
     app()

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "Programming Language :: Python :: 3.8",
     ],
     packages=find_namespace_packages(exclude=["tests"]),  # Required
-    install_requires=["bioimageio.spec", "imageio>=2.5", "numpy", "ruamel.yaml", "tqdm", "xarray"],
+    install_requires=["bioimageio.spec>=0.3.3post7", "imageio>=2.5", "numpy", "ruamel.yaml", "tqdm", "xarray"],
     include_package_data=True,
     extras_require={
         "test": ["pytest", "black", "mypy"],

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "Programming Language :: Python :: 3.8",
     ],
     packages=find_namespace_packages(exclude=["tests"]),  # Required
-    install_requires=["bioimageio.spec>=0.3.3post7", "imageio>=2.5", "numpy", "ruamel.yaml", "tqdm", "xarray"],
+    install_requires=["bioimageio.spec>=0.3.3", "imageio>=2.5", "numpy", "ruamel.yaml", "tqdm", "xarray"],
     include_package_data=True,
     extras_require={
         "test": ["pytest", "black", "mypy"],


### PR DESCRIPTION
requires https://github.com/bioimage-io/spec-bioimage-io/pull/269
and then adds `bioimageio.core 0.4.3` to the help/version string:

```
$bioimageio
Usage: bioimageio [OPTIONS] COMMAND [ARGS]...

  bioimageio.spec 0.3.3post6
  implementing:
          general RDF 0.2.0
          model RDF 0.3.3
  bioimageio.core 0.4.3

Options:
  --install-completion   Install completion for the current shell.
  --show-completion      Show completion for the current shell, to copy it or
                         customize the installation.

  -h, --help, --version  Show this message and exit.

Commands:
  convert-torch-weights-to-onnx   Convert model weights from format...
  convert-torch-weights-to-torchscript
                                  Convert model weights from format...
  package                         Package a BioImage.IO resource...
  predict-image                   Run prediction for a single set of...
  predict-images                  Predict multiple inputs with a...
  test-model                      Test whether the test output(s) of a...
  test-resource                   Test RDF dynamically Returns summary...
  validate                        Validate a BioImage.IO Resource...

Process finished with exit code 0
```

of coure also when running a command:
```
$ bioimageio validate lala
bioimageio.spec 0.3.3post6
implementing:
	general RDF 0.2.0
	model RDF 0.3.3
bioimageio.core 0.4.3
Error in lala:
"expected loaded resource to be a dictionary, but got type <class 'str'>: lala"
```
