### PR TITLE
Update scale range

### DIFF
--- a/bioimageio/core/prediction_pipeline/_processing.py
+++ b/bioimageio/core/prediction_pipeline/_processing.py
@@ -166,6 +166,7 @@ class ScaleRange(Processing):
     axes: Optional[Sequence[str]] = None
     min_percentile: float = 0.0
     max_percentile: float = 100.0
+    eps: float = 1e-6
     reference_tensor: Optional[str] = None
 
     def get_required_dataset_statistics(self) -> Dict[str, Set[Measure]]:
@@ -209,7 +210,7 @@ class ScaleRange(Processing):
         v_lower = get_stat(ref_name, Percentile(self.min_percentile, axes=axes))
         v_upper = get_stat(ref_name, Percentile(self.max_percentile, axes=axes))
 
-        return ensure_dtype((tensor - v_lower) / (v_upper - v_lower), dtype="float32")
+        return ensure_dtype((tensor - v_lower) / (v_upper - v_lower + self.eps), dtype="float32")
 
     def __post_init__(self):
         super().__post_init__()

--- a/bioimageio/core/prediction_pipeline/_processing.py
+++ b/bioimageio/core/prediction_pipeline/_processing.py
@@ -209,7 +209,7 @@ class ScaleRange(Processing):
         v_lower = get_stat(ref_name, Percentile(self.min_percentile, axes=axes))
         v_upper = get_stat(ref_name, Percentile(self.max_percentile, axes=axes))
 
-        return ensure_dtype((tensor - v_lower) / v_upper, dtype="float32")
+        return ensure_dtype((tensor - v_lower) / (v_upper - v_lower), dtype="float32")
 
     def __post_init__(self):
         super().__post_init__()

--- a/tests/prediction_pipeline/test_preprocessing.py
+++ b/tests/prediction_pipeline/test_preprocessing.py
@@ -131,11 +131,13 @@ def test_scale_range():
         )
     )
 
-    exp_data = (np_data - np_data.min()) / np_data.max()
+    mi, ma = np_data.min(), np_data.max()
+    exp_data = (np_data - mi) / (ma - mi)
     expected = xr.DataArray(exp_data, dims=("x", "y"))
 
     result = preprocessing(data)
-    xr.testing.assert_allclose(expected, result)
+    # NOTE xarray.testing.assert_allclose compares irrelavant properties here and fails although the result is correct
+    np.testing.assert_allclose(expected, result)
 
 
 def test_scale_range_axes():
@@ -158,11 +160,12 @@ def test_scale_range_axes():
 
     p_low = np.percentile(np_data, min_percentile, axis=(1, 2), keepdims=True)
     p_up = np.percentile(np_data, max_percentile, axis=(1, 2), keepdims=True)
-    exp_data = (np_data - p_low) / p_up
+    exp_data = (np_data - p_low) / (p_up - p_low)
     expected = xr.DataArray(exp_data, dims=("c", "x", "y"))
 
     result = preprocessing(data)
-    xr.testing.assert_allclose(expected, result)
+    # NOTE xarray.testing.assert_allclose compares irrelavant properties here and fails although the result is correct
+    np.testing.assert_allclose(expected, result)
 
 
 def test_sigmoid():

--- a/tests/prediction_pipeline/test_preprocessing.py
+++ b/tests/prediction_pipeline/test_preprocessing.py
@@ -131,8 +131,9 @@ def test_scale_range():
         )
     )
 
+    eps = 1.0e-6
     mi, ma = np_data.min(), np_data.max()
-    exp_data = (np_data - mi) / (ma - mi)
+    exp_data = (np_data - mi) / (ma - mi + eps)
     expected = xr.DataArray(exp_data, dims=("x", "y"))
 
     result = preprocessing(data)
@@ -158,9 +159,10 @@ def test_scale_range_axes():
         )
     )
 
+    eps = 1.0e-6
     p_low = np.percentile(np_data, min_percentile, axis=(1, 2), keepdims=True)
     p_up = np.percentile(np_data, max_percentile, axis=(1, 2), keepdims=True)
-    exp_data = (np_data - p_low) / (p_up - p_low)
+    exp_data = (np_data - p_low) / (p_up - p_low + eps)
     expected = xr.DataArray(exp_data, dims=("c", "x", "y"))
 
     result = preprocessing(data)


### PR DESCRIPTION
Our implementation of `scale_range` is different than the one in csbdeep: https://github.com/CSBDeep/CSBDeep/blob/master/csbdeep/utils/utils.py#L51-L75.
Hence we cannot reproduce the stardist models right now, see also https://github.com/stardist/stardist/pull/171.

@FynnBe I am not sure what's the best strategy here: we can either just change the function or add a flag for the CSBDeep style normalization.

PR builds on #141.