### PR TITLE
Bump patch

### DIFF
--- a/bioimageio/core/VERSION
+++ b/bioimageio/core/VERSION
@@ -1,3 +1,3 @@
 {
-    "version": "0.4.3post0"
+    "version": "0.4.4"
 }

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "Programming Language :: Python :: 3.8",
     ],
     packages=find_namespace_packages(exclude=["tests"]),  # Required
-    install_requires=["bioimageio.spec>=0.3.3", "imageio>=2.5", "numpy", "ruamel.yaml", "tqdm", "xarray"],
+    install_requires=["bioimageio.spec>=0.3.4", "imageio>=2.5", "numpy", "ruamel.yaml", "tqdm", "xarray"],
     include_package_data=True,
     extras_require={
         "test": ["pytest", "black", "mypy"],


### PR DESCRIPTION
and require new `bioimageio.spec` version (still need to wait for this to get on conda-forge).