### PR TITLE
make some Arguments Options

### DIFF
--- a/bioimageio/core/__main__.py
+++ b/bioimageio/core/__main__.py
@@ -70,9 +70,9 @@ def test_model(
     model_rdf: str = typer.Argument(
         ..., help="Path or URL to the model resource description file (rdf.yaml) or zipped model."
     ),
-    weight_format: Optional[WeightFormatEnum] = typer.Argument(None, help="The weight format to use."),
-    devices: Optional[List[str]] = typer.Argument(None, help="Devices for running the model."),
-    decimal: int = typer.Argument(4, help="The test precision."),
+    weight_format: Optional[WeightFormatEnum] = typer.Option(None, help="The weight format to use."),
+    devices: Optional[List[str]] = typer.Option(None, help="Devices for running the model."),
+    decimal: int = typer.Option(4, help="The test precision."),
 ) -> int:
     # this is a weird typer bug: default devices are empty tuple although they should be None
     if len(devices) == 0:
@@ -95,9 +95,9 @@ def test_resource(
     rdf: str = typer.Argument(
         ..., help="Path or URL to the resource description file (rdf.yaml) or zipped resource package."
     ),
-    weight_format: Optional[WeightFormatEnum] = typer.Argument(None, help="(for model only) The weight format to use."),
-    devices: Optional[List[str]] = typer.Argument(None, help="(for model only) Devices for running the model."),
-    decimal: int = typer.Argument(4, help="(for model only) The test precision."),
+    weight_format: Optional[WeightFormatEnum] = typer.Option(None, help="(for model only) The weight format to use."),
+    devices: Optional[List[str]] = typer.Option(None, help="(for model only) Devices for running the model."),
+    decimal: int = typer.Option(4, help="(for model only) The test precision."),
 ) -> int:
     # this is a weird typer bug: default devices are empty tuple although they should be None
     if len(devices) == 0:
@@ -129,10 +129,10 @@ def predict_image(
     # tiling: Optional[Union[str, bool]] = typer.Argument(
     #     None, help="Padding to apply in each dimension passed as json encoded string."
     # ),
-    padding: Optional[bool] = typer.Argument(None, help="Whether to pad the image to a size suited for the model."),
-    tiling: Optional[bool] = typer.Argument(None, help="Whether to run prediction in tiling mode."),
-    weight_format: Optional[str] = typer.Argument(None, help="The weight format to use."),
-    devices: Optional[List[str]] = typer.Argument(None, help="Devices for running the model."),
+    padding: Optional[bool] = typer.Option(None, help="Whether to pad the image to a size suited for the model."),
+    tiling: Optional[bool] = typer.Option(None, help="Whether to run prediction in tiling mode."),
+    weight_format: Optional[str] = typer.Option(None, help="The weight format to use."),
+    devices: Optional[List[str]] = typer.Option(None, help="Devices for running the model."),
 ) -> int:
 
     if isinstance(padding, str):
@@ -167,10 +167,10 @@ def predict_images(
     # tiling: Optional[Union[str, bool]] = typer.Argument(
     #     None, help="Padding to apply in each dimension passed as json encoded string."
     # ),
-    padding: Optional[bool] = typer.Argument(None, help="Whether to pad the image to a size suited for the model."),
-    tiling: Optional[bool] = typer.Argument(None, help="Whether to run prediction in tiling mode."),
-    weight_format: Optional[str] = typer.Argument(None, help="The weight format to use."),
-    devices: Optional[List[str]] = typer.Argument(None, help="Devices for running the model."),
+    padding: Optional[bool] = typer.Option(None, help="Whether to pad the image to a size suited for the model."),
+    tiling: Optional[bool] = typer.Option(None, help="Whether to run prediction in tiling mode."),
+    weight_format: Optional[str] = typer.Option(None, help="The weight format to use."),
+    devices: Optional[List[str]] = typer.Option(None, help="Devices for running the model."),
 ) -> int:
     input_files = glob(input_pattern)
     input_names = [os.path.split(infile)[1] for infile in input_files]
@@ -213,8 +213,8 @@ if torch_converter is not None:
         ),
         output_path: Path = typer.Argument(..., help="Where to save the onnx weights."),
         opset_version: Optional[int] = typer.Argument(12, help="Onnx opset version."),
-        use_tracing: bool = typer.Argument(True, help="Whether to use torch.jit tracing or scripting."),
-        verbose: bool = typer.Argument(True, help="Verbosity"),
+        use_tracing: bool = typer.Option(True, help="Whether to use torch.jit tracing or scripting."),
+        verbose: bool = typer.Option(True, help="Verbosity"),
     ) -> int:
         return torch_converter.convert_weights_to_onnx(model_rdf, output_path, opset_version, use_tracing, verbose)
 
@@ -226,7 +226,7 @@ if torch_converter is not None:
             ..., help="Path to the model resource description file (rdf.yaml) or zipped model."
         ),
         output_path: Path = typer.Argument(..., help="Where to save the torchscript weights."),
-        use_tracing: bool = typer.Argument(True, help="Whether to use torch.jit tracing or scripting."),
+        use_tracing: bool = typer.Option(True, help="Whether to use torch.jit tracing or scripting."),
     ) -> int:
         return torch_converter.convert_weights_to_pytorch_script(model_rdf, output_path, use_tracing)
 


### PR DESCRIPTION
We use a lot of `typer.Argument` in the CLI. I think some of the input should rather be a `typer.Option`.
E.g. for `test-model` was:
```
$ bioimageio test-model --help
bioimageio.spec 0.3.4
implementing:
        general RDF 0.2.0
        model RDF 0.3.4
bioimageio.core 0.4.3
Usage: __main__.py test-model [OPTIONS] MODEL_RDF [WEIGHT_FORMAT]:[pytorch_sta
                              te_dict|pytorch_script|keras_hdf5|tensorflow_js|
                              tensorflow_saved_model_bundle|onnx] [DEVICES]...
                              [DECIMAL]

  Test whether the test output(s) of a model can be reproduced.

  Returns summary dict with "error" and "traceback" key; summary["error"] is
  None if no errors were encountered.

Arguments:
  MODEL_RDF                       Path or URL to the model resource
                                  description file (rdf.yaml) or zipped model.
                                  [required]

  [WEIGHT_FORMAT]:[pytorch_state_dict|pytorch_script|keras_hdf5|tensorflow_js|tensorflow_saved_model_bundle|onnx]
                                  The weight format to use.
  [DEVICES]...                    Devices for running the model.
  [DECIMAL]                       The test precision.  [default: 4]

Options:
  -h, --help, --version  Show this message and exit.

```
and is now:
```
$ bioimageio test-model --help
bioimageio.spec 0.3.4
implementing:
        general RDF 0.2.0
        model RDF 0.3.4
bioimageio.core 0.4.3
Usage: __main__.py test-model [OPTIONS] MODEL_RDF

  Test whether the test output(s) of a model can be reproduced.

  Returns summary dict with "error" and "traceback" key; summary["error"] is
  None if no errors were encountered.

Arguments:
  MODEL_RDF  Path or URL to the model resource description file (rdf.yaml) or
             zipped model.  [required]


Options:
  --weight-format [pytorch_state_dict|pytorch_script|keras_hdf5|tensorflow_js|tensorflow_saved_model_bundle|onnx]
                                  The weight format to use.
  --devices TEXT                  Devices for running the model.
  --decimal INTEGER               The test precision.  [default: 4]
  -h, --help, --version           Show this message and exit.

```

I think this makes it easier to read and use.