### PR TITLE
add unload for PredictionPipeline and ModelAdapters

### DIFF
--- a/bioimageio/core/prediction_pipeline/_model_adapters/_keras_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_keras_model_adapter.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import List, Optional
+from typing import List, Optional, Sequence
 
 import keras
 import xarray as xr
@@ -17,7 +17,7 @@ class KerasModelAdapter(ModelAdapter):
         self._model = keras.models.load_model(weight_file)
         self._output_axes = [tuple(out.axes) for out in self.bioimageio_model.outputs]
 
-    def forward(self, *input_tensors: xr.DataArray) -> List[xr.DataArray]:
+    def _forward(self, *input_tensors: xr.DataArray) -> List[xr.DataArray]:
         result = self._model.predict(*input_tensors)
         if not isinstance(result, (tuple, list)):
             result = [result]

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_keras_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_keras_model_adapter.py
@@ -11,11 +11,14 @@ class KerasModelAdapter(ModelAdapter):
     def _load(self, *, devices: Optional[Sequence[str]] = None) -> None:
         # TODO keras device management
         if devices is not None:
-            warnings.warn(f"Device management is not implemented for tensorflow yet, ignoring the devices {devices}")
+            warnings.warn(f"Device management is not implemented for keras yet, ignoring the devices {devices}")
 
         weight_file = self.bioimageio_model.weights["keras_hdf5"].source
         self._model = keras.models.load_model(weight_file)
         self._output_axes = [tuple(out.axes) for out in self.bioimageio_model.outputs]
+
+    def _unload(self) -> None:
+        warnings.warn("Device management is not implemented for keras yet, cannot unload model")
 
     def _forward(self, *input_tensors: xr.DataArray) -> List[xr.DataArray]:
         result = self._model.predict(*input_tensors)

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_keras_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_keras_model_adapter.py
@@ -4,19 +4,18 @@ from typing import List, Optional
 import keras
 import xarray as xr
 
-from bioimageio.core.resource_io import nodes
 from ._model_adapter import ModelAdapter
 
 
 class KerasModelAdapter(ModelAdapter):
-    def __init__(self, *, bioimageio_model: nodes.Model, devices: Optional[List[str]] = None):
+    def _load(self, *, devices: Optional[Sequence[str]] = None) -> None:
         # TODO keras device management
         if devices is not None:
             warnings.warn(f"Device management is not implemented for tensorflow yet, ignoring the devices {devices}")
 
-        weight_file = bioimageio_model.weights["keras_hdf5"].source
+        weight_file = self.bioimageio_model.weights["keras_hdf5"].source
         self._model = keras.models.load_model(weight_file)
-        self._output_axes = [tuple(out.axes) for out in bioimageio_model.outputs]
+        self._output_axes = [tuple(out.axes) for out in self.bioimageio_model.outputs]
 
     def forward(self, *input_tensors: xr.DataArray) -> List[xr.DataArray]:
         result = self._model.predict(*input_tensors)

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_model_adapter.py
@@ -100,7 +100,6 @@ def create_model_adapter(
     Note: All specific adapters should happen inside this function to prevent different framework
     initializations interfering with each other
     """
-    spec = bioimageio_model
     weights = bioimageio_model.weights
     weight_formats = get_weight_formats()
 
@@ -115,7 +114,7 @@ def create_model_adapter(
             return adapter_cls(bioimageio_model=bioimageio_model, devices=devices)
 
     raise RuntimeError(
-        f"weight format {weight_format} not among weight formats listed in model: {list(spec.weights.keys())}"
+        f"weight format {weight_format} not among weight formats listed in model: {list(bioimageio_model.weights.keys())}"
     )
 
 

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_model_adapter.py
@@ -93,7 +93,7 @@ def get_weight_formats() -> List[str]:
 
 
 def create_model_adapter(
-    *, bioimageio_model: nodes.Model, devices=Optional[List[str]], weight_format: Optional[str] = None
+    *, bioimageio_model: nodes.Model, devices=Optional[Sequence[str]], weight_format: Optional[str] = None
 ) -> ModelAdapter:
     """
     Creates model adapter based on the passed spec

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_model_adapter.py
@@ -1,11 +1,11 @@
 import abc
-from typing import List, Optional, Type
+from typing import List, Optional, Sequence, Type
 
 import xarray as xr
 
 from bioimageio.core.resource_io import nodes
 
-#: Known weigh types in order of priority
+#: Known weight formats in order of priority
 #: First match wins
 _WEIGHT_FORMATS = ["pytorch_state_dict", "tensorflow_saved_model_bundle", "pytorch_script", "onnx", "keras_hdf5"]
 
@@ -15,8 +15,22 @@ class ModelAdapter(abc.ABC):
     Represents model *without* any preprocessing and postprocessing
     """
 
+    def __init__(self, *, bioimageio_model: nodes.Model, devices: Optional[Sequence[str]] = None):
+        self.bioimageio_model = bioimageio_model
+        self.default_devices = devices
+
+    def load(self, *, devices: Optional[Sequence[str]] = None):
+        """
+        Load model onto devices. If devices is None, self.default_devices are chosen
+        (which may be None as well, in which case a framework dependent default is chosen)
+        """
+        return self._load(devices=devices or self.default_devices)
+
     @abc.abstractmethod
-    def __init__(self, *, bioimageio_model: nodes.Model, devices=Optional[List[str]]):
+    def _load(self, *, devices: Optional[Sequence[str]] = None):
+        """
+        Load model onto devices. If devices is None a framework dependent default is chosen
+        """
         ...
 
     @abc.abstractmethod

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_model_adapter.py
@@ -72,15 +72,17 @@ class ModelAdapter(abc.ABC):
         Unload model from any devices, freeing their memory.
         Note: Use ModelAdapter as context to not worry about calling unload()!
         """
+        # implementation of non-state-machine logic in _unload()
         assert self.loaded
         self._unload()
         self.loaded = False
 
+    @abc.abstractmethod
     def _unload(self) -> None:
         """
-        Implementation of unload(). Overwrite this in framework specific model adapter implementation
+        Unload model from any devices, freeing their memory.
         """
-        raise NotImplementedError
+        ...
 
 
 def get_weight_formats() -> List[str]:

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_onnx_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_onnx_model_adapter.py
@@ -29,3 +29,6 @@ class ONNXModelAdapter(ModelAdapter):
             result = []
 
         return [xr.DataArray(r, dims=axes) for r, axes in zip(result, self._internal_output_axes)]
+
+    def _unload(self) -> None:
+        warnings.warn("Device management is not implemented for onnx yet, cannot unload model")

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_onnx_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_onnx_model_adapter.py
@@ -5,19 +5,16 @@ from typing import List, Optional
 import onnxruntime as rt
 import xarray as xr
 
-from bioimageio.core.resource_io import nodes
 from ._model_adapter import ModelAdapter
 
 logger = logging.getLogger(__name__)
 
 
 class ONNXModelAdapter(ModelAdapter):
-    def __init__(self, *, bioimageio_model: nodes.Model, devices: Optional[List[str]] = None):
-        spec = bioimageio_model
+    def _load(self, *, devices: Optional[List[str]] = None):
+        self._internal_output_axes = [tuple(out.axes) for out in self.bioimageio_model.outputs]
 
-        self._internal_output_axes = [tuple(out.axes) for out in bioimageio_model.outputs]
-
-        self._session = rt.InferenceSession(str(spec.weights["onnx"].source))
+        self._session = rt.InferenceSession(str(self.bioimageio_model.weights["onnx"].source))
         onnx_inputs = self._session.get_inputs()
         self._input_names = [ipt.name for ipt in onnx_inputs]
 

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_onnx_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_onnx_model_adapter.py
@@ -21,7 +21,7 @@ class ONNXModelAdapter(ModelAdapter):
         if devices is not None:
             warnings.warn(f"Device management is not implemented for onnx yet, ignoring the devices {devices}")
 
-    def forward(self, *input_tensors: xr.DataArray) -> List[xr.DataArray]:
+    def _forward(self, *input_tensors: xr.DataArray) -> List[xr.DataArray]:
         assert len(input_tensors) == len(self._input_names)
         input_arrays = [ipt.data for ipt in input_tensors]
         result = self._session.run(None, dict(zip(self._input_names, input_arrays)))

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_pytorch_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_pytorch_model_adapter.py
@@ -26,7 +26,7 @@ class PytorchModelAdapter(ModelAdapter):
 
         self._internal_output_axes = [tuple(out.axes) for out in self.bioimageio_model.outputs]
 
-    def forward(self, *input_tensors: xr.DataArray) -> List[xr.DataArray]:
+    def _forward(self, *input_tensors: xr.DataArray) -> List[xr.DataArray]:
         with torch.no_grad():
             tensors = [torch.from_numpy(ipt.data) for ipt in input_tensors]
             tensors = [t.to(self._devices[0]) for t in tensors]

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_tensorflow_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_tensorflow_model_adapter.py
@@ -90,7 +90,7 @@ class TensorflowModelAdapterBase(ModelAdapter):
 
         return [r if isinstance(r, np.ndarray) else tf.make_ndarray(r) for r in result]
 
-    def forward(self, *input_tensors: xr.DataArray) -> List[xr.DataArray]:
+    def _forward(self, *input_tensors: xr.DataArray) -> List[xr.DataArray]:
         data = [ipt.data for ipt in input_tensors]
         if self.use_keras_api:
             result = self._forward_keras(*data)

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_tensorflow_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_tensorflow_model_adapter.py
@@ -99,6 +99,9 @@ class TensorflowModelAdapterBase(ModelAdapter):
 
         return [xr.DataArray(r, dims=axes) for r, axes in zip(result, self._internal_output_axes)]
 
+    def _unload(self) -> None:
+        warnings.warn("Device management is not implemented for keras yet, cannot unload model")
+
 
 class TensorflowModelAdapter(TensorflowModelAdapterBase):
     weight_format = "tensorflow_saved_model_bundle"

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_torchscript_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_torchscript_model_adapter.py
@@ -19,7 +19,7 @@ class TorchscriptModelAdapter(ModelAdapter):
         self._model.to(devices[0])
         self._internal_output_axes = [tuple(out.axes) for out in self.bioimageio_model.outputs]
 
-    def forward(self, *batch: xr.DataArray) -> List[xr.DataArray]:
+    def _forward(self, *batch: xr.DataArray) -> List[xr.DataArray]:
         with torch.no_grad():
             torch_tensor = [torch.from_numpy(b.data) for b in batch]
             result = self._model.forward(*torch_tensor)

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_torchscript_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_torchscript_model_adapter.py
@@ -4,13 +4,12 @@ import numpy as np
 import torch
 import xarray as xr
 
-from bioimageio.core.resource_io import nodes
 from ._model_adapter import ModelAdapter
 
 
 class TorchscriptModelAdapter(ModelAdapter):
-    def __init__(self, *, bioimageio_model: nodes.Model, devices: Optional[List[str]] = None):
-        weight_path = str(bioimageio_model.weights["pytorch_script"].source.resolve())
+    def _load(self, *, devices: Optional[List[str]] = None):
+        weight_path = str(self.bioimageio_model.weights["pytorch_script"].source.resolve())
         if devices is None:
             devices = ["cuda" if torch.cuda.is_available() else "cpu"]
         else:
@@ -18,7 +17,7 @@ class TorchscriptModelAdapter(ModelAdapter):
 
         self._model = torch.jit.load(weight_path)
         self._model.to(devices[0])
-        self._internal_output_axes = [tuple(out.axes) for out in bioimageio_model.outputs]
+        self._internal_output_axes = [tuple(out.axes) for out in self.bioimageio_model.outputs]
 
     def forward(self, *batch: xr.DataArray) -> List[xr.DataArray]:
         with torch.no_grad():

--- a/bioimageio/core/prediction_pipeline/_model_adapters/_torchscript_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_torchscript_model_adapter.py
@@ -17,7 +17,7 @@ class TorchscriptModelAdapter(ModelAdapter):
         else:
             self.devices = [torch.device(d) for d in devices]
 
-        if len(devices) > 1:
+        if len(self.devices) > 1:
             warnings.warn("Multiple devices for single torchscript model not yet implemented")
 
         self._model = torch.jit.load(weight_path)

--- a/bioimageio/core/prediction_pipeline/_prediction_pipeline.py
+++ b/bioimageio/core/prediction_pipeline/_prediction_pipeline.py
@@ -87,7 +87,6 @@ class _PredictionPipelineImpl(PredictionPipeline):
     def __init__(
         self, *, name: str, bioimageio_model: Model, processing: CombinedProcessing, model: ModelAdapter
     ) -> None:
-        super().__init__(bioimageio_model=bioimageio_model)
         if bioimageio_model.run_mode:
             raise NotImplementedError(f"Not yet implemented inference for run mode '{bioimageio_model.run_mode.name}'")
 

--- a/bioimageio/core/prediction_pipeline/_prediction_pipeline.py
+++ b/bioimageio/core/prediction_pipeline/_prediction_pipeline.py
@@ -23,7 +23,7 @@ class NamedImplicitOutputShape:
         return len(self.scale)
 
 
-class PredictionPipeline(ModelAdapter):
+class PredictionPipeline(abc.ABC):
     """
     Represents model computation including preprocessing and postprocessing
     """

--- a/bioimageio/core/prediction_pipeline/_prediction_pipeline.py
+++ b/bioimageio/core/prediction_pipeline/_prediction_pipeline.py
@@ -64,6 +64,7 @@ class _PredictionPipelineImpl(PredictionPipeline):
     def __init__(
         self, *, name: str, bioimageio_model: Model, processing: CombinedProcessing, model: ModelAdapter
     ) -> None:
+        super().__init__(bioimageio_model=bioimageio_model)
         if bioimageio_model.run_mode:
             raise NotImplementedError(f"Not yet implemented inference for run mode '{bioimageio_model.run_mode.name}'")
 

--- a/bioimageio/core/prediction_pipeline/_prediction_pipeline.py
+++ b/bioimageio/core/prediction_pipeline/_prediction_pipeline.py
@@ -1,7 +1,7 @@
 import abc
 import math
 from dataclasses import dataclass
-from typing import List, Optional, Tuple, Dict, Any
+from typing import List, Optional, Sequence, Tuple, Dict, Any
 
 import xarray as xr
 from marshmallow import missing
@@ -174,7 +174,7 @@ def enforce_min_shape(min_shape, step, axes):
 
 
 def create_prediction_pipeline(
-    *, bioimageio_model: nodes.Model, devices: Optional[List[str]] = None, weight_format: Optional[str] = None
+    *, bioimageio_model: nodes.Model, devices: Optional[Sequence[str]] = None, weight_format: Optional[str] = None
 ) -> PredictionPipeline:
     """
     Creates prediction pipeline which includes:

--- a/bioimageio/core/utils.py
+++ b/bioimageio/core/utils.py
@@ -1,0 +1,23 @@
+from functools import wraps
+from typing import Type
+
+
+def skip_on(exception: Type[Exception], reason: str):
+    """adapted from https://stackoverflow.com/a/63522579"""
+    import pytest
+
+    # Func below is the real decorator and will receive the test function as param
+    def decorator_func(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            try:
+                # Try to run the test
+                return f(*args, **kwargs)
+            except exception:
+                # If exception of given type happens
+                # just swallow it and raise pytest.Skip with given reason
+                pytest.skip(reason)
+
+        return wrapper
+
+    return decorator_func

--- a/tests/prediction_pipeline/test_device_management.py
+++ b/tests/prediction_pipeline/test_device_management.py
@@ -1,0 +1,81 @@
+from functools import wraps
+
+import numpy as np
+import pytest
+import xarray as xr
+from numpy.testing import assert_array_almost_equal
+
+from bioimageio.core import load_resource_description
+from bioimageio.core.resource_io.nodes import Model
+from bioimageio.core.utils import skip_on
+
+
+class TooFewDevicesException(Exception):
+    pass
+
+
+def _test_device_management(model_package, weight_format):
+    import torch
+
+    if torch.cuda.device_count() == 0:
+        raise TooFewDevicesException("Need at least one cuda device for this test")
+
+    from bioimageio.core.prediction_pipeline import create_prediction_pipeline
+
+    bio_model = load_resource_description(model_package)
+    assert isinstance(bio_model, Model)
+    pred_pipe = create_prediction_pipeline(bioimageio_model=bio_model, weight_format=weight_format)
+
+    inputs = [
+        xr.DataArray(np.load(str(test_tensor)), dims=tuple(spec.axes))
+        for test_tensor, spec in zip(bio_model.test_inputs, bio_model.inputs)
+    ]
+    with pred_pipe as pp:
+        outputs = pp.forward(*inputs)
+
+    assert isinstance(outputs, list)
+
+    expected_outputs = [
+        xr.DataArray(np.load(str(test_tensor)), dims=tuple(spec.axes))
+        for test_tensor, spec in zip(bio_model.test_outputs, bio_model.outputs)
+    ]
+
+    assert len(outputs) == len(expected_outputs)
+    for out, exp in zip(outputs, expected_outputs):
+        assert_array_almost_equal(out, exp, decimal=4)
+
+    # repeat inference with context manager to test load/unload/load/forward
+    with pred_pipe as pp:
+        outputs = pp.forward(*inputs)
+
+    assert len(outputs) == len(expected_outputs)
+    for out, exp in zip(outputs, expected_outputs):
+        assert_array_almost_equal(out, exp, decimal=4)
+
+
+@skip_on(TooFewDevicesException, reason="Too few devices")
+def test_device_management_torch(any_torch_model):
+    _test_device_management(any_torch_model, "pytorch_state_dict")
+
+
+@skip_on(TooFewDevicesException, reason="Too few devices")
+def test_device_management_torchscript(any_torchscript_model):
+    _test_device_management(any_torchscript_model, "pytorch_script")
+
+
+@pytest.mark.skipif(pytest.skip_torch, reason="requires torch for device discovery")
+@skip_on(TooFewDevicesException, reason="Too few devices")
+def test_device_management_onnx(any_onnx_model):
+    _test_device_management(any_onnx_model, "onnx")
+
+
+@pytest.mark.skipif(pytest.skip_torch, reason="requires torch for device discovery")
+@skip_on(TooFewDevicesException, reason="Too few devices")
+def test_device_management_tensorflow(any_tensorflow_model):
+    _test_device_management(any_tensorflow_model, "tensorflow_saved_model_bundle")
+
+
+@pytest.mark.skipif(pytest.skip_torch, reason="requires torch for device discovery")
+@skip_on(TooFewDevicesException, reason="Too few devices")
+def test_device_management_keras(any_keras_model):
+    _test_device_management(any_keras_model, "keras_hdf5")

--- a/tests/prediction_pipeline/test_device_management.py
+++ b/tests/prediction_pipeline/test_device_management.py
@@ -24,7 +24,7 @@ def _test_device_management(model_package, weight_format):
 
     bio_model = load_resource_description(model_package)
     assert isinstance(bio_model, Model)
-    pred_pipe = create_prediction_pipeline(bioimageio_model=bio_model, weight_format=weight_format)
+    pred_pipe = create_prediction_pipeline(bioimageio_model=bio_model, weight_format=weight_format, devices=["cuda:0"])
 
     inputs = [
         xr.DataArray(np.load(str(test_tensor)), dims=tuple(spec.axes))


### PR DESCRIPTION
This PR
 - adds `load` and `unload` methods to `PredictionPipeline` and any `ModelAdapter` to occupy and free device (gpu) memory
 - enables the use of `PredictionPipeline` and any `ModelAdapter` as context
 - makes any `ModelAdapter` keep track if it's loaded and loads on the fly when calling forward and unloaded

With this PR the use of PredictionPipeline and ModelAdapter as context managers is encouraged, while the previous use is still fully functional.

Atm, only `pytorch_state_dict` and `pytorch_script` models actually unload, TF and keras model adapters give a warning and skip unloading.