### PR TITLE
Fix shape val

### DIFF
--- a/bioimageio/core/__main__.py
+++ b/bioimageio/core/__main__.py
@@ -1,6 +1,7 @@
 import enum
 import json
 import os
+import sys
 from glob import glob
 
 from pathlib import Path
@@ -53,9 +54,10 @@ def package(
     # typer bug: typer returns empty tuple instead of None if weights_order_priority is not given
     weights_priority_order = weights_priority_order or None
 
-    return commands.package(
+    ret_code = commands.package(
         rdf_source=rdf_source, path=path, weights_priority_order=weights_priority_order, verbose=verbose
     )
+    sys.exit(ret_code)
 
 
 package.__doc__ = commands.package.__doc__
@@ -89,11 +91,12 @@ def test_model(
     )
     if summary["error"] is None:
         print(f"Model test for {model_rdf} has passed.")
-        return 0
+        ret_code = 0
     else:
         print(f"Model test for {model_rdf} has FAILED!")
         print(summary)
-        return 1
+        ret_code = 1
+    sys.exit(ret_code)
 
 
 test_model.__doc__ = resource_tests.test_model.__doc__
@@ -116,11 +119,12 @@ def test_resource(
     )
     if summary["error"] is None:
         print(f"Resource test for {rdf} has passed.")
-        return 0
+        ret_code = 0
     else:
         print(f"Resource test for {rdf} has FAILED!")
         print(summary)
-        return 1
+        ret_code = 1
+    sys.exit(ret_code)
 
 
 test_resource.__doc__ = resource_tests.test_resource.__doc__
@@ -159,7 +163,6 @@ def predict_image(
     prediction.predict_image(
         model_rdf, inputs, outputs, padding, tiling, None if weight_format is None else weight_format.value, devices
     )
-    return 0
 
 
 predict_image.__doc__ = prediction.predict_image.__doc__
@@ -211,7 +214,6 @@ def predict_images(
         devices=devices,
         verbose=True,
     )
-    return 0
 
 
 predict_images.__doc__ = prediction.predict_images.__doc__
@@ -241,7 +243,8 @@ if torch_converter is not None:
         output_path: Path = typer.Argument(..., help="Where to save the torchscript weights."),
         use_tracing: bool = typer.Option(True, help="Whether to use torch.jit tracing or scripting."),
     ) -> int:
-        return torch_converter.convert_weights_to_pytorch_script(model_rdf, output_path, use_tracing)
+        ret_code = torch_converter.convert_weights_to_pytorch_script(model_rdf, output_path, use_tracing)
+        sys.exit(ret_code)
 
     convert_torch_weights_to_torchscript.__doc__ = torch_converter.convert_weights_to_pytorch_script.__doc__
 

--- a/bioimageio/core/commands.py
+++ b/bioimageio/core/commands.py
@@ -32,6 +32,13 @@ def package(
 
     try:
         rdf_local_source = resolve_uri(rdf_source)
+    except Exception as e:
+        print(f"Failed to resolve RDF source {rdf_source}: {e}")
+        if verbose:
+            traceback.print_exc()
+        return 1
+
+    try:
         path = path.with_name(path.name.format(src_name=rdf_local_source.stem))
         shutil.move(tmp_package_path, path)
     except Exception as e:

--- a/bioimageio/core/resource_tests.py
+++ b/bioimageio/core/resource_tests.py
@@ -51,9 +51,7 @@ def _validate_input_shape(shape: Tuple[int, ...], shape_spec) -> bool:
         # check if the shape is valid for all dimension by seeing if it can be reached with an integer number of steps
         # NOTE we allow that the valid shape is reached using a different number of steps for each axis here
         # this is usually valid because dimensions are independent in neural networks
-        is_valid = [
-            (sh - minsh) % st == 0 if st > 0 else sh == minsh for sh, st, minsh in zip(shape, step, min_shape)
-        ]
+        is_valid = [(sh - minsh) % st == 0 if st > 0 else sh == minsh for sh, st, minsh in zip(shape, step, min_shape)]
         return all(is_valid)
     else:
         raise TypeError(f"Encountered unexpected shape description of type {type(shape_spec)}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,10 @@ model_sources = {
         "https://raw.githubusercontent.com/bioimage-io/spec-bioimage-io/main/example_specs/models/"
         "stardist_example_model/rdf_wrong_shape.yaml"
     ),
+    "stardist_wrong_shape2": (
+        "https://raw.githubusercontent.com/bioimage-io/spec-bioimage-io/main/example_specs/models/"
+        "stardist_example_model/rdf_wrong_shape2.yaml"
+    ),
 }
 
 try:
@@ -94,6 +98,7 @@ if not skip_tensorflow:
     if tf_major_version == 1:
         load_model_packages |= set(tensorflow1_models)
         load_model_packages.add("stardist_wrong_shape")
+        load_model_packages.add("stardist_wrong_shape2")
     elif tf_major_version == 2:
         load_model_packages |= set(tensorflow2_models)
 
@@ -121,6 +126,12 @@ def unet2d_nuclei_broad_model(request):
 # written as model group to automatically skip on missing tensorflow 1
 @pytest.fixture(params=[] if skip_tensorflow or tf_major_version != 1 else ["stardist_wrong_shape"])
 def stardist_wrong_shape(request):
+    return pytest.model_packages[request.param]
+
+
+# written as model group to automatically skip on missing tensorflow 1
+@pytest.fixture(params=[] if skip_tensorflow or tf_major_version != 1 else ["stardist_wrong_shape2"])
+def stardist_wrong_shape2(request):
     return pytest.model_packages[request.param]
 
 
@@ -165,7 +176,7 @@ def any_tensorflow_js_model(request):
 # fixture to test with all models that should run in the current environment
 # we exclude stardist_wrong_shape here because it is not a valid model
 # and included only to test that validation for this model fails
-@pytest.fixture(params=load_model_packages - {"stardist_wrong_shape"})
+@pytest.fixture(params=load_model_packages - {"stardist_wrong_shape", "stardist_wrong_shape2"})
 def any_model(request):
     return pytest.model_packages[request.param]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,6 +21,11 @@ def test_cli_test_model(unet2d_nuclei_broad_model):
     assert ret.returncode == 0
 
 
+def test_cli_test_model_fail(stardist_wrong_shape):
+    ret = subprocess.run(["bioimageio", "test-model", stardist_wrong_shape])
+    assert ret.returncode == 1
+
+
 def test_cli_test_model_with_weight_format(unet2d_nuclei_broad_model):
     ret = subprocess.run(
         ["bioimageio", "test-model", unet2d_nuclei_broad_model, "--weight-format", "pytorch_state_dict"]

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -8,18 +8,6 @@ from bioimageio.core import load_resource_description
 from bioimageio.core.resource_io.nodes import Model
 
 
-def test_test_model(any_model):
-    from bioimageio.core.resource_tests import test_model
-
-    assert test_model(any_model)
-
-
-def test_test_resource(any_model):
-    from bioimageio.core.resource_tests import test_resource
-
-    assert test_resource(any_model)
-
-
 def test_predict_image(any_model, tmpdir):
     from bioimageio.core.prediction import predict_image
 

--- a/tests/test_resource_tests/test_test_model.py
+++ b/tests/test_resource_tests/test_test_model.py
@@ -3,7 +3,7 @@ def test_error_for_wrong_shape(stardist_wrong_shape):
 
     summary = test_model(stardist_wrong_shape)
     expected_error_message = (
-        "Shape of test output 0 'output' does not match output shape description: "
+        "Shape (1, 512, 512, 33) of test output 0 'output' does not match output shape description: "
         "ImplicitOutputShape(reference_tensor='input', "
         "scale=[1.0, 1.0, 1.0, 0.0], offset=[1.0, 1.0, 1.0, 33.0])."
     )

--- a/tests/test_resource_tests/test_test_model.py
+++ b/tests/test_resource_tests/test_test_model.py
@@ -2,7 +2,21 @@ def test_error_for_wrong_shape(stardist_wrong_shape):
     from bioimageio.core.resource_tests import test_model
 
     summary = test_model(stardist_wrong_shape)
-    assert (
-        summary["error"]
-        == "Shape of test input 0 'input' does not match input shape description: ParametrizedInputShape(min=[1, 16, 16, 1], step=[0, 16, 16, 0])"
-    )
+    expected_error_message = ("Shape of test output 0 'output' does not match output shape description: "
+                              "ImplicitOutputShape(reference_tensor='input', "
+                              "scale=[1.0, 1.0, 1.0, 0.0], offset=[1.0, 1.0, 1.0, 33.0]).")
+    assert summary["error"] == expected_error_message
+
+
+def test_test_model(any_model):
+    from bioimageio.core.resource_tests import test_model
+
+    summary = test_model(any_model)
+    assert summary["error"] is None
+
+
+def test_test_resource(any_model):
+    from bioimageio.core.resource_tests import test_resource
+
+    summary = test_resource(any_model)
+    assert summary["error"] is None

--- a/tests/test_resource_tests/test_test_model.py
+++ b/tests/test_resource_tests/test_test_model.py
@@ -10,6 +10,17 @@ def test_error_for_wrong_shape(stardist_wrong_shape):
     assert summary["error"] == expected_error_message
 
 
+def test_error_for_wrong_shape2(stardist_wrong_shape2):
+    from bioimageio.core.resource_tests import test_model
+
+    summary = test_model(stardist_wrong_shape2)
+    expected_error_message = (
+        "Shape (1, 512, 512, 1) of test input 0 'input' does not match input shape description: "
+        "ParametrizedInputShape(min=[1, 16, 16, 1], step=[0, 17, 17, 0])."
+    )
+    assert summary["error"] == expected_error_message
+
+
 def test_test_model(any_model):
     from bioimageio.core.resource_tests import test_model
 

--- a/tests/test_resource_tests/test_test_model.py
+++ b/tests/test_resource_tests/test_test_model.py
@@ -2,9 +2,11 @@ def test_error_for_wrong_shape(stardist_wrong_shape):
     from bioimageio.core.resource_tests import test_model
 
     summary = test_model(stardist_wrong_shape)
-    expected_error_message = ("Shape of test output 0 'output' does not match output shape description: "
-                              "ImplicitOutputShape(reference_tensor='input', "
-                              "scale=[1.0, 1.0, 1.0, 0.0], offset=[1.0, 1.0, 1.0, 33.0]).")
+    expected_error_message = (
+        "Shape of test output 0 'output' does not match output shape description: "
+        "ImplicitOutputShape(reference_tensor='input', "
+        "scale=[1.0, 1.0, 1.0, 0.0], offset=[1.0, 1.0, 1.0, 33.0])."
+    )
     assert summary["error"] == expected_error_message
 
 


### PR DESCRIPTION
Fixes the input/output shape validation which did not work at all; we just did not notice because the tests for `test_model` where also broken...
In addition this also fixes the return codes from all CLI functions, which always returned 0 before.