### PR TITLE
Uri vs path

### DIFF
--- a/bioimageio/core/build_spec/build_model.py
+++ b/bioimageio/core/build_spec/build_model.py
@@ -10,7 +10,7 @@ import numpy as np
 import bioimageio.spec as spec
 import bioimageio.spec.model as model_spec
 from bioimageio.core import export_resource_package, load_raw_resource_description
-from bioimageio.core.resource_io.utils import resolve_uri
+from bioimageio.core.resource_io.utils import resolve_source
 
 try:
     from typing import get_args
@@ -34,7 +34,7 @@ def _process_uri(uri: Union[str, Path], root: Path, download=False):
     elif (root / uri).exists():
         return root / uri
     elif isinstance(uri, str) and uri.startswith("http"):
-        return resolve_uri(uri, root) if download else uri
+        return resolve_source(uri, root) if download else uri
     else:
         raise ValueError(f"Invalid uri: {uri}")
 

--- a/bioimageio/core/build_spec/build_model.py
+++ b/bioimageio/core/build_spec/build_model.py
@@ -1,7 +1,7 @@
 import datetime
 import hashlib
 import os
-from pathlib import Path
+from pathlib import Path, WindowsPath
 from shutil import copyfile
 from typing import Any, Dict, List, Optional, Union, Tuple
 
@@ -239,11 +239,11 @@ def _build_cite(cite: Dict[str, str]):
 
 
 def _get_dependencies(dependencies, root):
-    if ":" in dependencies:
-        manager, path = dependencies.split(":")
-    else:
+    if isinstance(dependencies, Path) or ":" not in dependencies:
         manager = "conda"
-        path = dependencies
+        path = Path(dependencies)
+    else:
+        manager, path = dependencies.split(":")
     return model_spec.raw_nodes.Dependencies(manager=manager, file=resolve_source(path, root))
 
 
@@ -289,7 +289,7 @@ def build_model(
     run_mode: Optional[str] = None,
     parent: Optional[Tuple[str, str]] = None,
     config: Optional[Dict[str, Any]] = None,
-    dependencies: Optional[str] = None,
+    dependencies: Optional[Union[Path, str]] = None,
     links: Optional[List[str]] = None,
     root: Optional[Union[Path, str]] = None,
     **weight_kwargs,

--- a/bioimageio/core/build_spec/build_model.py
+++ b/bioimageio/core/build_spec/build_model.py
@@ -30,7 +30,7 @@ def _get_hash(path):
 
 def _infer_weight_type(path):
     ext = os.path.splitext(path)[-1]
-    if ext in (".pt", ".torch"):
+    if ext in (".pt", ".pth", ".torch"):
         return "pytorch_state_dict"
     elif ext == ".onnx":
         return "onnx"

--- a/bioimageio/core/build_spec/build_model.py
+++ b/bioimageio/core/build_spec/build_model.py
@@ -10,7 +10,7 @@ import numpy as np
 import bioimageio.spec as spec
 import bioimageio.spec.model as model_spec
 from bioimageio.core import export_resource_package, load_raw_resource_description
-from bioimageio.core.resource_io.utils import resolve_source
+from bioimageio.core.resource_io.utils import resolve_local_source, resolve_source
 
 try:
     from typing import get_args
@@ -26,17 +26,6 @@ def _get_hash(path):
     with open(path, "rb") as f:
         data = f.read()
         return hashlib.sha256(data).hexdigest()
-
-
-def _process_uri(uri: Union[str, Path], root: Path, download=False):
-    if os.path.exists(uri):
-        return Path(uri)
-    elif (root / uri).exists():
-        return root / uri
-    elif isinstance(uri, str) and uri.startswith("http"):
-        return resolve_source(uri, root) if download else uri
-    else:
-        raise ValueError(f"Invalid uri: {uri}")
 
 
 def _infer_weight_type(path):
@@ -56,7 +45,7 @@ def _infer_weight_type(path):
 
 
 def _get_weights(weight_uri, weight_type, source, root, **kwargs):
-    weight_path = _process_uri(weight_uri, root, download=True)
+    weight_path = resolve_source(weight_uri, root)
     if weight_type is None:
         weight_type = _infer_weight_type(weight_path)
     weight_hash = _get_hash(weight_path)
@@ -68,7 +57,7 @@ def _get_weights(weight_uri, weight_type, source, root, **kwargs):
         source_file, source_class = source.replace("::", ":").split(":")
 
         # get the source path
-        source_file = _process_uri(source_file, root, download=True)
+        source_file = resolve_source(source_file, root)
         source_hash = _get_hash(source_file)
 
         # if not relative, create local copy (otherwise this will not work)
@@ -88,7 +77,7 @@ def _get_weights(weight_uri, weight_type, source, root, **kwargs):
         attachments = {}
 
     weight_types = model_spec.raw_nodes.WeightsFormat
-    weight_source = _process_uri(weight_uri, root)
+    weight_source = resolve_local_source(weight_uri, root)
     if weight_type == "pytorch_state_dict":
         # pytorch-state-dict -> we need a source
         assert source is not None
@@ -255,7 +244,7 @@ def _get_dependencies(dependencies, root):
     else:
         manager = "conda"
         path = dependencies
-    return model_spec.raw_nodes.Dependencies(manager=manager, file=_process_uri(path, root))
+    return model_spec.raw_nodes.Dependencies(manager=manager, file=resolve_source(path, root))
 
 
 def build_model(
@@ -380,8 +369,8 @@ def build_model(
 
     assert len(test_inputs)
     assert len(test_outputs)
-    test_inputs = [_process_uri(uri, root) for uri in test_inputs]
-    test_outputs = [_process_uri(uri, root) for uri in test_outputs]
+    test_inputs = resolve_local_source(test_inputs, root)
+    test_outputs = resolve_local_source(test_outputs, root)
 
     n_inputs = len(test_inputs)
     input_name = n_inputs * [None] if input_name is None else input_name
@@ -431,8 +420,8 @@ def build_model(
 
     authors = _build_authors(authors)
     cite = _build_cite(cite)
-    documentation = _process_uri(documentation, root, download=True)
-    covers = [_process_uri(uri, root, download=True) for uri in covers]
+    documentation = resolve_source(documentation, root)
+    covers = resolve_source(covers, root)
 
     # parse the weights
     weights, language, framework, source, source_hash, tmp_source = _get_weights(

--- a/bioimageio/core/build_spec/build_model.py
+++ b/bioimageio/core/build_spec/build_model.py
@@ -1,9 +1,9 @@
 import datetime
 import hashlib
 import os
-from pathlib import Path, WindowsPath
+from pathlib import Path
 from shutil import copyfile
-from typing import Any, Dict, List, Optional, Union, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 

--- a/bioimageio/core/commands.py
+++ b/bioimageio/core/commands.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import List, Optional, Union
 
 from bioimageio.core import export_resource_package
-from bioimageio.core.resource_io.utils import resolve_uri
+from bioimageio.core.resource_io.utils import resolve_source
 from bioimageio.spec.commands import validate
 from bioimageio.spec.shared.raw_nodes import URI
 
@@ -31,7 +31,7 @@ def package(
         return 1
 
     try:
-        rdf_local_source = resolve_uri(rdf_source)
+        rdf_local_source = resolve_source(rdf_source)
     except Exception as e:
         print(f"Failed to resolve RDF source {rdf_source}: {e}")
         if verbose:

--- a/bioimageio/core/resource_io/io_.py
+++ b/bioimageio/core/resource_io/io_.py
@@ -17,7 +17,7 @@ from bioimageio.spec.shared.common import BIOIMAGEIO_CACHE_PATH, get_class_name_
 from bioimageio.spec.shared.raw_nodes import ResourceDescription as RawResourceDescription
 from bioimageio.spec.shared.utils import PathToRemoteUriTransformer
 from . import nodes
-from .utils import resolve_raw_resource_description, resolve_uri
+from .utils import resolve_raw_resource_description, resolve_source
 
 serialize_raw_resource_description = spec.io_.serialize_raw_resource_description
 save_raw_resource_description = spec.io_.save_raw_resource_description
@@ -41,7 +41,7 @@ def extract_resource_package(
                 download = None
                 break
         else:
-            download = resolve_uri(root)
+            download = resolve_source(root)
 
         local_source = download
     else:
@@ -169,7 +169,7 @@ def get_local_resource_package_content(
     local_package_content = {}
     for k, v in package_content.items():
         if isinstance(v, raw_nodes.URI):
-            v = resolve_uri(v, raw_rd.root_path)
+            v = resolve_source(v, raw_rd.root_path)
         elif isinstance(v, pathlib.Path):
             v = raw_rd.root_path / v
 

--- a/bioimageio/core/resource_io/utils.py
+++ b/bioimageio/core/resource_io/utils.py
@@ -136,7 +136,7 @@ class RawNodeTypeTransformer(NodeTransformer):
             return super().generic_transformer(node)
 
 
-@singledispatch
+@singledispatch  # todo: fix type annotations
 def resolve_source(source, root_path: os.PathLike = pathlib.Path()):
     raise TypeError(type(source))
 
@@ -190,10 +190,13 @@ def _resolve_source_list(source: list, root_path: os.PathLike = pathlib.Path()) 
     return [resolve_source(el, root_path) for el in source]
 
 
+# todo: write as singledispatch with type annotations
 def resolve_local_source(
-    source: typing.Union[str, os.PathLike, raw_nodes.URI], root_path: os.PathLike
-) -> typing.Union[pathlib.Path, raw_nodes.URI]:
-    if isinstance(source, os.PathLike) or isinstance(source, str):
+    source: typing.Union[str, os.PathLike, raw_nodes.URI, tuple, list], root_path: os.PathLike
+) -> typing.Union[pathlib.Path, raw_nodes.URI, list, tuple]:
+    if isinstance(source, (tuple, list)):
+        return type(source)([resolve_local_source(s, root_path) for s in source])
+    elif isinstance(source, os.PathLike) or isinstance(source, str):
         if isinstance(source, str):
             try:  # source as path from cwd
                 is_path_cwd = pathlib.Path(source).exists()

--- a/bioimageio/core/resource_io/utils.py
+++ b/bioimageio/core/resource_io/utils.py
@@ -144,8 +144,7 @@ def resolve_source(uri, root_path: os.PathLike = pathlib.Path()):
 
 @resolve_source.register
 def _resolve_source_uri_node(uri: raw_nodes.URI, root_path: os.PathLike = pathlib.Path()) -> pathlib.Path:
-    assert isinstance(uri, (raw_nodes.URI, nodes.URI))
-    path_or_remote_uri = resolve_local_uri(uri, root_path)
+    path_or_remote_uri = resolve_local_source(uri, root_path)
     if isinstance(path_or_remote_uri, raw_nodes.URI):
         local_path = _download_url_to_local_path(path_or_remote_uri)
     elif isinstance(path_or_remote_uri, pathlib.Path):
@@ -192,7 +191,7 @@ def _resolve_source_list(uri: list, root_path: os.PathLike = pathlib.Path()) -> 
     return [resolve_source(el, root_path) for el in uri]
 
 
-def resolve_local_uri(
+def resolve_local_source(
     uri: typing.Union[str, os.PathLike, raw_nodes.URI], root_path: os.PathLike
 ) -> typing.Union[pathlib.Path, raw_nodes.URI]:
     if isinstance(uri, os.PathLike) or isinstance(uri, str):
@@ -241,7 +240,7 @@ def resolve_local_uri(
 
 
 def uri_available(uri: raw_nodes.URI, root_path: pathlib.Path) -> bool:
-    local_path_or_remote_uri = resolve_local_uri(uri, root_path)
+    local_path_or_remote_uri = resolve_local_source(uri, root_path)
     if isinstance(local_path_or_remote_uri, raw_nodes.URI):
         response = requests.head(str(local_path_or_remote_uri))
         available = response.status_code == 200

--- a/bioimageio/core/resource_io/utils.py
+++ b/bioimageio/core/resource_io/utils.py
@@ -211,8 +211,10 @@ def resolve_local_source(
             if not is_path_cwd and is_path_rp:
                 source = path_from_root
 
-        if is_path_cwd or is_path_rp or isinstance(source, os.PathLike):
+        if is_path_cwd or is_path_rp:
             return pathlib.Path(source)
+        elif isinstance(source, os.PathLike):
+            raise FileNotFoundError(f"Could neither find {source} nor {pathlib.Path(root_path) / source}")
 
     if isinstance(source, str):
         uri = fields.URI().deserialize(source)

--- a/bioimageio/core/resource_io/utils.py
+++ b/bioimageio/core/resource_io/utils.py
@@ -197,26 +197,21 @@ def resolve_local_source(
     if isinstance(source, (tuple, list)):
         return type(source)([resolve_local_source(s, root_path) for s in source])
     elif isinstance(source, os.PathLike) or isinstance(source, str):
-        if isinstance(source, str):
-            try:  # source as path from cwd
-                is_path_cwd = pathlib.Path(source).exists()
-            except OSError:
-                is_path_cwd = False
+        try:  # source as path from cwd
+            is_path_cwd = pathlib.Path(source).exists()
+        except OSError:
+            is_path_cwd = False
 
-            try:  # source as relative path from root_path
-                path_from_root = pathlib.Path(root_path) / source
-                is_path_rp = (path_from_root).exists()
-            except OSError:
-                is_path_rp = False
-            else:
-                if not is_path_cwd and is_path_rp:
-                    source = path_from_root
-
-            is_path = is_path_cwd or is_path_rp
+        try:  # source as relative path from root_path
+            path_from_root = pathlib.Path(root_path) / source
+            is_path_rp = (path_from_root).exists()
+        except OSError:
+            is_path_rp = False
         else:
-            is_path = True
+            if not is_path_cwd and is_path_rp:
+                source = path_from_root
 
-        if is_path:
+        if is_path_cwd or is_path_rp or isinstance(source, os.PathLike):
             return pathlib.Path(source)
 
     if isinstance(source, str):

--- a/example/bioimageio-core-usage.ipynb
+++ b/example/bioimageio-core-usage.ipynb
@@ -328,7 +328,7 @@
     "    # the source information\n",
     "    model_source = raw_resource.source\n",
     "    # download the source file if necessary\n",
-    "    source_file = bioimageio.core.resource_io.utils.resolve_uri(\n",
+    "    source_file = bioimageio.core.resource_io.utils.resolve_source(\n",
     "        model_source.source_file\n",
     "    )\n",
     "    # if the source file path does not exist, try combining it with the root path of the model\n",

--- a/tests/build_spec/test_build_spec.py
+++ b/tests/build_spec/test_build_spec.py
@@ -8,7 +8,7 @@ def _test_build_spec(spec_path, out_path, weight_type, tensorflow_version=None, 
 
     model_spec = load_raw_resource_description(spec_path)
     assert isinstance(model_spec, spec.model.raw_nodes.Model)
-    weight_source = model_spec.weights[weight_type].source.path
+    weight_source = model_spec.weights[weight_type].source
 
     cite = {entry.text: entry.doi if entry.url is missing else entry.url for entry in model_spec.cite}
 

--- a/tests/build_spec/test_build_spec.py
+++ b/tests/build_spec/test_build_spec.py
@@ -1,6 +1,7 @@
 from marshmallow import missing
 import bioimageio.spec as spec
 from bioimageio.core.resource_io.io_ import load_raw_resource_description
+from bioimageio.core.resource_io.utils import resolve_source
 
 
 def _test_build_spec(spec_path, out_path, weight_type, tensorflow_version=None, use_implicit_output_shape=False):
@@ -13,7 +14,7 @@ def _test_build_spec(spec_path, out_path, weight_type, tensorflow_version=None, 
     cite = {entry.text: entry.doi if entry.url is missing else entry.url for entry in model_spec.cite}
 
     if weight_type == "pytorch_state_dict":
-        source_path = model_spec.source.source_file.path
+        source_path = model_spec.source.source_file
         class_name = model_spec.source.callable_name
         model_source = f"{source_path}:{class_name}"
         weight_type_ = None  # the weight type can be auto-detected
@@ -24,15 +25,15 @@ def _test_build_spec(spec_path, out_path, weight_type, tensorflow_version=None, 
         model_source = None
         weight_type_ = None  # the weight type can be auto-detected
 
-    dep_file = None if model_spec.dependencies is missing else model_spec.dependencies.file.path
+    dep_file = None if model_spec.dependencies is missing else resolve_source(model_spec.dependencies.file)
     authors = [{"name": auth.name, "affiliation": auth.affiliation} for auth in model_spec.authors]
-    covers = [cover.path for cover in model_spec.covers]
+    covers = resolve_source(model_spec.covers)
     kwargs = dict(
         source=model_source,
         model_kwargs=model_spec.kwargs,
         weight_uri=weight_source,
-        test_inputs=[inp.path for inp in model_spec.test_inputs],
-        test_outputs=[outp.path for outp in model_spec.test_outputs],
+        test_inputs=resolve_source(model_spec.test_inputs),
+        test_outputs=resolve_source(model_spec.test_outputs),
         name=model_spec.name,
         description=model_spec.description,
         authors=authors,

--- a/tests/build_spec/test_build_spec.py
+++ b/tests/build_spec/test_build_spec.py
@@ -8,6 +8,7 @@ def _test_build_spec(spec_path, out_path, weight_type, tensorflow_version=None, 
     from bioimageio.core.build_spec import build_model
 
     model_spec = load_raw_resource_description(spec_path)
+    root = model_spec.root_path
     assert isinstance(model_spec, spec.model.raw_nodes.Model)
     weight_source = model_spec.weights[weight_type].source
 
@@ -25,15 +26,15 @@ def _test_build_spec(spec_path, out_path, weight_type, tensorflow_version=None, 
         model_source = None
         weight_type_ = None  # the weight type can be auto-detected
 
-    dep_file = None if model_spec.dependencies is missing else resolve_source(model_spec.dependencies.file)
+    dep_file = None if model_spec.dependencies is missing else resolve_source(model_spec.dependencies.file, root)
     authors = [{"name": auth.name, "affiliation": auth.affiliation} for auth in model_spec.authors]
-    covers = resolve_source(model_spec.covers)
+    covers = resolve_source(model_spec.covers, root)
     kwargs = dict(
         source=model_source,
         model_kwargs=model_spec.kwargs,
         weight_uri=weight_source,
-        test_inputs=resolve_source(model_spec.test_inputs),
-        test_outputs=resolve_source(model_spec.test_outputs),
+        test_inputs=resolve_source(model_spec.test_inputs, root),
+        test_outputs=resolve_source(model_spec.test_outputs, root),
         name=model_spec.name,
         description=model_spec.description,
         authors=authors,

--- a/tests/resource_io/test_load_rdf.py
+++ b/tests/resource_io/test_load_rdf.py
@@ -6,7 +6,7 @@ from tempfile import NamedTemporaryFile
 import pytest
 from marshmallow import ValidationError
 
-from bioimageio.core.resource_io.utils import resolve_uri
+from bioimageio.core.resource_io.utils import resolve_source
 
 
 def test_load_non_existing_rdf():
@@ -84,4 +84,4 @@ def test_load_remote_model_with_folders():
     assert isinstance(raw_model, raw_nodes.Model)
     model = load_resource_description(rdf_url)
     assert isinstance(model, nodes.Model)
-    assert resolve_uri(raw_model.documentation) == model.documentation
+    assert resolve_source(raw_model.documentation) == model.documentation

--- a/tests/resource_io/test_utils.py
+++ b/tests/resource_io/test_utils.py
@@ -8,7 +8,7 @@ def test_resolve_import_path(tmpdir):
     tmpdir = Path(tmpdir)
     manifest_path = tmpdir / "manifest.yaml"
     manifest_path.touch()
-    source_file = nodes.URI(path="my_mod.py")
+    source_file = Path("my_mod.py")
     (tmpdir / str(source_file)).write_text("class Foo: pass", encoding="utf8")
     node = raw_nodes.ImportableSourceFile(source_file=source_file, callable_name="Foo")
     uri_transformed = utils.UriNodeTransformer(root_path=tmpdir).transform(node)
@@ -33,8 +33,8 @@ def test_all_uris_available():
     from bioimageio.core.resource_io.utils import all_uris_available
 
     not_available = {
-        "uri": raw_nodes.URI(path="non_existing_file_in/non_existing_dir/ftw"),
-        "uri_exists": raw_nodes.URI(path="."),
+        "uri": raw_nodes.URI(scheme="file", path="non_existing_file_in/non_existing_dir/ftw"),
+        "uri_exists": raw_nodes.URI(scheme="file", path="."),
     }
     assert not all_uris_available(not_available)
 

--- a/tests/resource_io/test_utils.py
+++ b/tests/resource_io/test_utils.py
@@ -30,13 +30,13 @@ def test_uri_available():
 
 
 def test_all_uris_available():
-    from bioimageio.core.resource_io.utils import all_uris_available
+    from bioimageio.core.resource_io.utils import all_sources_available
 
     not_available = {
         "uri": raw_nodes.URI(scheme="file", path="non_existing_file_in/non_existing_dir/ftw"),
         "uri_exists": raw_nodes.URI(scheme="file", path="."),
     }
-    assert not all_uris_available(not_available)
+    assert not all_sources_available(not_available)
 
 
 def test_uri_node_transformer_is_ok_with_abs_path():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import subprocess
+from typing import Sequence
 
 import numpy as np
 import pytest
@@ -6,43 +7,48 @@ import pytest
 from bioimageio.core import load_resource_description
 
 
+def run_subprocess(commands: Sequence[str]) -> subprocess.CompletedProcess:
+    # return subprocess.run(commands, capture_output=True)
+    return subprocess.run(commands, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding="utf-8")
+
+
 def test_validate_model(unet2d_nuclei_broad_model):
-    ret = subprocess.run(["bioimageio", "validate", unet2d_nuclei_broad_model])
-    assert ret.returncode == 0
+    ret = run_subprocess(["bioimageio", "validate", unet2d_nuclei_broad_model])
+    assert ret.returncode == 0, ret.stdout
 
 
 def test_cli_package(unet2d_nuclei_broad_model):
-    ret = subprocess.run(["bioimageio", "package", unet2d_nuclei_broad_model])
-    assert ret.returncode == 0
+    ret = run_subprocess(["bioimageio", "package", unet2d_nuclei_broad_model])
+    assert ret.returncode == 0, ret.stdout
 
 
 def test_cli_test_model(unet2d_nuclei_broad_model):
-    ret = subprocess.run(["bioimageio", "test-model", unet2d_nuclei_broad_model])
-    assert ret.returncode == 0
+    ret = run_subprocess(["bioimageio", "test-model", unet2d_nuclei_broad_model])
+    assert ret.returncode == 0, ret.stdout
 
 
 def test_cli_test_model_fail(stardist_wrong_shape):
-    ret = subprocess.run(["bioimageio", "test-model", stardist_wrong_shape])
+    ret = run_subprocess(["bioimageio", "test-model", stardist_wrong_shape])
     assert ret.returncode == 1
 
 
 def test_cli_test_model_with_weight_format(unet2d_nuclei_broad_model):
-    ret = subprocess.run(
+    ret = run_subprocess(
         ["bioimageio", "test-model", unet2d_nuclei_broad_model, "--weight-format", "pytorch_state_dict"]
     )
-    assert ret.returncode == 0
+    assert ret.returncode == 0, ret.stdout
 
 
 def test_cli_test_resource(unet2d_nuclei_broad_model):
-    ret = subprocess.run(["bioimageio", "test-model", unet2d_nuclei_broad_model])
-    assert ret.returncode == 0
+    ret = run_subprocess(["bioimageio", "test-model", unet2d_nuclei_broad_model])
+    assert ret.returncode == 0, ret.stdout
 
 
 def test_cli_test_resource_with_weight_format(unet2d_nuclei_broad_model):
-    ret = subprocess.run(
+    ret = run_subprocess(
         ["bioimageio", "test-model", unet2d_nuclei_broad_model, "--weight-format", "pytorch_state_dict"]
     )
-    assert ret.returncode == 0
+    assert ret.returncode == 0, ret.stdout
 
 
 def _test_cli_predict_image(model, tmp_path, extra_kwargs=None):
@@ -52,8 +58,8 @@ def _test_cli_predict_image(model, tmp_path, extra_kwargs=None):
     cmd = ["bioimageio", "predict-image", model, "--inputs", str(in_path), "--outputs", str(out_path)]
     if extra_kwargs is not None:
         cmd.extend(extra_kwargs)
-    ret = subprocess.run(cmd)
-    assert ret.returncode == 0
+    ret = run_subprocess(cmd)
+    assert ret.returncode == 0, ret.stdout
     assert out_path.exists()
 
 
@@ -86,8 +92,8 @@ def _test_cli_predict_images(model, tmp_path, extra_kwargs=None):
     cmd = ["bioimageio", "predict-images", model, input_pattern, str(out_folder)]
     if extra_kwargs is not None:
         cmd.extend(extra_kwargs)
-    ret = subprocess.run(cmd)
-    assert ret.returncode == 0
+    ret = run_subprocess(cmd)
+    assert ret.returncode == 0, ret.stdout
 
     for out_path in expected_outputs:
         assert out_path.exists()
@@ -104,16 +110,16 @@ def test_cli_predict_images_with_weight_format(unet2d_nuclei_broad_model, tmp_pa
 
 def test_torch_to_torchscript(unet2d_nuclei_broad_model, tmp_path):
     out_path = tmp_path.with_suffix(".pt")
-    ret = subprocess.run(
+    ret = run_subprocess(
         ["bioimageio", "convert-torch-weights-to-torchscript", str(unet2d_nuclei_broad_model), str(out_path)]
     )
-    assert ret.returncode == 0
+    assert ret.returncode == 0, ret.stdout
     assert out_path.exists()
 
 
 @pytest.mark.skipif(pytest.skip_onnx, reason="requires torch and onnx")
 def test_torch_to_onnx(unet2d_nuclei_broad_model, tmp_path):
     out_path = tmp_path.with_suffix(".onnx")
-    ret = subprocess.run(["bioimageio", "convert-torch-weights-to-onnx", str(unet2d_nuclei_broad_model), str(out_path)])
-    assert ret.returncode == 0
+    ret = run_subprocess(["bioimageio", "convert-torch-weights-to-onnx", str(unet2d_nuclei_broad_model), str(out_path)])
+    assert ret.returncode == 0, ret.stdout
     assert out_path.exists()


### PR DESCRIPTION
needs https://github.com/bioimage-io/spec-bioimage-io/pull/288

This PR updates the use of URI classes and pathlib.Path as relative paths are no longer considered valid URIs. Union[URI, Path] is used where appropriate.
Also improves some util functions.