### PR TITLE
Check that samples are packaged in build_spec tests

### DIFF
--- a/bioimageio/core/build_spec/build_model.py
+++ b/bioimageio/core/build_spec/build_model.py
@@ -229,10 +229,6 @@ def _get_output_tensor(path, name, reference_tensor, scale, offset, axes, data_r
     return outputs
 
 
-def _build_authors(authors: List[Dict[str, str]]):
-    return [model_spec.raw_nodes.Author(**a) for a in authors]
-
-
 # TODO The citation entry should be improved so that we can properly derive doi vs. url
 def _build_cite(cite: Dict[str, str]):
     citation_list = [model_spec.raw_nodes.CiteEntry(text=k, url=v) for k, v in cite.items()]
@@ -564,6 +560,7 @@ def build_model(
     postprocessing: Optional[List[Dict[str, Dict[str, Union[int, float, str]]]]] = None,
     pixel_sizes: Optional[List[Dict[str, float]]] = None,
     # general optional
+    maintainers: Optional[List[Dict[str, str]]] = None,
     license: Optional[str] = None,
     covers: Optional[List[str]] = None,
     git_repo: Optional[str] = None,
@@ -731,7 +728,7 @@ def build_model(
     format_version = get_args(model_spec.raw_nodes.FormatVersion)[-1]
     timestamp = datetime.datetime.now()
 
-    authors = _build_authors(authors)
+    authors = [model_spec.raw_nodes.Author(**a) for a in authors]
     cite = _build_cite(cite)
     documentation = _ensure_local(documentation, root)
     if covers is None:
@@ -822,6 +819,8 @@ def build_model(
     if parent is not None:
         assert len(parent) == 2
         kwargs["parent"] = {"uri": parent[0], "sha256": parent[1]}
+    if maintainers is not None:
+        kwargs["maintainers"] = [model_spec.raw_nodes.Maintainer(**m) for m in maintainers]
 
     try:
         model = model_spec.raw_nodes.Model(

--- a/tests/build_spec/test_build_spec.py
+++ b/tests/build_spec/test_build_spec.py
@@ -106,6 +106,13 @@ def _test_build_spec(
         loaded_config = loaded_model.config
         assert "deepimagej" in loaded_config
 
+    if loaded_model.sample_inputs is not missing:
+        for sample in loaded_model.sample_inputs:
+            assert sample.exists()
+    if loaded_model.sample_outputs is not missing:
+        for sample in loaded_model.sample_outputs:
+            assert sample.exists()
+
     attachments = loaded_model.attachments
     if attachments is not missing and attachments.files is not missing:
         for attached_file in attachments["files"]:

--- a/tests/build_spec/test_build_spec.py
+++ b/tests/build_spec/test_build_spec.py
@@ -79,6 +79,7 @@ def _test_build_spec(
         postprocessing=postprocessing,
         output_path=out_path,
         add_deepimagej_config=add_deepimagej_config,
+        maintainers=[{"github_user": "jane_doe"}],
     )
     if architecture is not None:
         kwargs["architecture"] = architecture
@@ -113,6 +114,7 @@ def _test_build_spec(
         for sample in loaded_model.sample_outputs:
             assert sample.exists()
 
+    assert loaded_model.maintainers[0].github_user == "jane_doe"
     attachments = loaded_model.attachments
     if attachments is not missing and attachments.files is not missing:
         for attached_file in attachments["files"]:


### PR DESCRIPTION
`sample_inputs` and `sample_outputs` are not automatically pacakged when included in the spec.
This should be fixed @FynnBe. (I added a test to `build_spec` this fails due to this issue; this causes the issue that Carlos just mentioned in the meeting.)