### PR TITLE
Enable to export old versions

### DIFF
--- a/bioimageio/core/__main__.py
+++ b/bioimageio/core/__main__.py
@@ -56,7 +56,7 @@ def package(
         show_default=False,
     ),
     verbose: bool = typer.Option(False, help="show traceback of exceptions"),
-) -> int:
+):
     # typer bug: typer returns empty tuple instead of None if weights_order_priority is not given
     weights_priority_order = weights_priority_order or None
 
@@ -85,7 +85,7 @@ def test_model(
     weight_format: Optional[WeightFormatEnum] = typer.Option(None, help="The weight format to use."),
     devices: Optional[List[str]] = typer.Option(None, help="Devices for running the model."),
     decimal: int = typer.Option(4, help="The test precision."),
-) -> int:
+):
     # this is a weird typer bug: default devices are empty tuple although they should be None
     if len(devices) == 0:
         devices = None
@@ -126,7 +126,7 @@ def test_resource(
     weight_format: Optional[WeightFormatEnum] = typer.Option(None, help="(for model only) The weight format to use."),
     devices: Optional[List[str]] = typer.Option(None, help="(for model only) Devices for running the model."),
     decimal: int = typer.Option(4, help="(for model only) The test precision."),
-) -> int:
+):
     # this is a weird typer bug: default devices are empty tuple although they should be None
     if len(devices) == 0:
         devices = None
@@ -164,7 +164,7 @@ def predict_image(
     tiling: Optional[bool] = typer.Option(None, help="Whether to run prediction in tiling mode."),
     weight_format: Optional[WeightFormatEnum] = typer.Option(None, help="The weight format to use."),
     devices: Optional[List[str]] = typer.Option(None, help="Devices for running the model."),
-) -> int:
+):
 
     if isinstance(padding, str):
         padding = json.loads(padding.replace("'", '"'))
@@ -203,7 +203,7 @@ def predict_images(
     tiling: Optional[bool] = typer.Option(None, help="Whether to run prediction in tiling mode."),
     weight_format: Optional[WeightFormatEnum] = typer.Option(None, help="The weight format to use."),
     devices: Optional[List[str]] = typer.Option(None, help="Devices for running the model."),
-) -> int:
+):
     input_files = glob(input_pattern)
     input_names = [os.path.split(infile)[1] for infile in input_files]
     output_files = [os.path.join(output_folder, fname) for fname in input_names]
@@ -246,7 +246,7 @@ if torch_converter is not None:
         opset_version: Optional[int] = typer.Argument(12, help="Onnx opset version."),
         use_tracing: bool = typer.Option(True, help="Whether to use torch.jit tracing or scripting."),
         verbose: bool = typer.Option(True, help="Verbosity"),
-    ) -> int:
+    ):
         ret_code = torch_converter.convert_weights_to_onnx(model_rdf, output_path, opset_version, use_tracing, verbose)
         sys.exit(ret_code)
 
@@ -259,7 +259,7 @@ if torch_converter is not None:
         ),
         output_path: Path = typer.Argument(..., help="Where to save the torchscript weights."),
         use_tracing: bool = typer.Option(True, help="Whether to use torch.jit tracing or scripting."),
-    ) -> int:
+    ):
         ret_code = torch_converter.convert_weights_to_torchscript(model_rdf, output_path, use_tracing)
         sys.exit(ret_code)
 
@@ -274,7 +274,7 @@ if keras_converter is not None:
             ..., help="Path to the model resource description file (rdf.yaml) or zipped model."
         ),
         output_path: Path = typer.Argument(..., help="Where to save the tensorflow weights."),
-    ) -> int:
+    ):
         ret_code = keras_converter.convert_weights_to_tensorflow_saved_model_bundle(model_rdf, output_path)
         sys.exit(ret_code)
 

--- a/bioimageio/core/build_spec/build_model.py
+++ b/bioimageio/core/build_spec/build_model.py
@@ -812,7 +812,7 @@ def build_model(
     kwargs = {k: v for k, v in optional_kwargs.items() if v is not None}
 
     if attachments is not None:
-        kwargs["attachments"] = model_spec.raw_nodes.Attachments(**attachments)
+        kwargs["attachments"] = spec.rdf.raw_nodes.Attachments(**attachments)
     if dependencies is not None:
         kwargs["dependencies"] = _get_dependencies(dependencies, root)
     if maintainers is not None:

--- a/bioimageio/core/resource_io/io_.py
+++ b/bioimageio/core/resource_io/io_.py
@@ -95,13 +95,16 @@ def _replace_relative_paths_for_remote_source(
 
 
 def load_raw_resource_description(
-    source: Union[dict, os.PathLike, IO, str, bytes, raw_nodes.URI, RawResourceDescription]
+    source: Union[dict, os.PathLike, IO, str, bytes, raw_nodes.URI, RawResourceDescription],
+    update_to_current_format: bool = True,
 ) -> RawResourceDescription:
     """load a raw python representation from a BioImage.IO resource description file (RDF).
     Use `load_resource_description` for a more convenient representation.
 
     Args:
         source: resource description file (RDF)
+        update_to_current_format: if True (default) attempt auto-conversion to latest format version
+            (most bioimageio.core functionality expects the latest format version for each resource)
 
     Returns:
         raw BioImage.IO resource
@@ -109,7 +112,7 @@ def load_raw_resource_description(
     if isinstance(source, RawResourceDescription):
         return source
 
-    raw_rd = spec.load_raw_resource_description(source, update_to_current_format=True)
+    raw_rd = spec.load_raw_resource_description(source, update_to_current_format=update_to_current_format)
     raw_rd = _replace_relative_paths_for_remote_source(raw_rd, raw_rd.root_path)
     return raw_rd
 
@@ -133,7 +136,7 @@ def load_resource_description(
     if isinstance(source, ResourceDescription):
         return source
 
-    raw_rd = load_raw_resource_description(source)
+    raw_rd = load_raw_resource_description(source, update_to_current_format=True)
 
     if weights_priority_order is not None:
         for wf in weights_priority_order:
@@ -181,26 +184,28 @@ def get_local_resource_package_content(
 def export_resource_package(
     source: Union[RawResourceDescription, os.PathLike, str, dict, raw_nodes.URI],
     *,
-    output_path: Optional[os.PathLike] = None,
-    weights_priority_order: Optional[Sequence[Union[str]]] = None,
     compression: int = ZIP_DEFLATED,
     compression_level: int = 1,
+    output_path: Optional[os.PathLike] = None,
+    update_to_current_format: bool = False,
+    weights_priority_order: Optional[Sequence[Union[str]]] = None,
 ) -> pathlib.Path:
     """Package a BioImage.IO resource as a zip file.
 
     Args:
         source: raw resource description, path, URI or raw data as dict
-        output_path: file path to write package to
-        weights_priority_order: If given only the first weights format present in the model is included.
-                                If none of the prioritized weights formats is found all are included.
         compression: The numeric constant of compression method.
         compression_level: Compression level to use when writing files to the archive.
                            See https://docs.python.org/3/library/zipfile.html#zipfile.ZipFile
+        output_path: file path to write package to
+        update_to_current_format: If True attempt auto-conversion to latest format version.
+        weights_priority_order: If given only the first weights format present in the model is included.
+                                If none of the prioritized weights formats is found all are included.
 
     Returns:
         path to zipped BioImage.IO package in BIOIMAGEIO_CACHE_PATH or 'output_path'
     """
-    raw_rd = load_raw_resource_description(source)
+    raw_rd = load_raw_resource_description(source, update_to_current_format=update_to_current_format)
     package_content = get_local_resource_package_content(raw_rd, weights_priority_order)
     if output_path is None:
         package_path = _get_tmp_package_path(raw_rd, weights_priority_order)

--- a/bioimageio/core/resource_io/io_.py
+++ b/bioimageio/core/resource_io/io_.py
@@ -96,17 +96,14 @@ def _replace_relative_paths_for_remote_source(
 
 def load_raw_resource_description(
     source: Union[dict, os.PathLike, IO, str, bytes, raw_nodes.URI, RawResourceDescription],
-    update_to_current_format: bool = True,
-    update_to_format: Optional[str] = None,
+    update_to_format: Optional[str] = "latest",
 ) -> RawResourceDescription:
     """load a raw python representation from a BioImage.IO resource description file (RDF).
     Use `load_resource_description` for a more convenient representation.
 
     Args:
         source: resource description file (RDF)
-        update_to_current_format: if True (default) attempt auto-conversion to latest format version
-            (most bioimageio.core functionality expects the latest format version for each resource)
-        update_to_format: update resource to specific major.minor format version; ignoring patch version.
+        update_to_format: update resource to specific "major.minor" or "latest" format version; ignoring patch version.
 
     Returns:
         raw BioImage.IO resource
@@ -114,9 +111,7 @@ def load_raw_resource_description(
     if isinstance(source, RawResourceDescription):
         return source
 
-    raw_rd = spec.load_raw_resource_description(
-        source, update_to_current_format=update_to_current_format, update_to_format=update_to_format
-    )
+    raw_rd = spec.load_raw_resource_description(source, update_to_format=update_to_format)
     raw_rd = _replace_relative_paths_for_remote_source(raw_rd, raw_rd.root_path)
     return raw_rd
 
@@ -191,7 +186,6 @@ def export_resource_package(
     compression: int = ZIP_DEFLATED,
     compression_level: int = 1,
     output_path: Optional[os.PathLike] = None,
-    update_to_current_format: bool = False,
     update_to_format: Optional[str] = None,
     weights_priority_order: Optional[Sequence[Union[str]]] = None,
 ) -> pathlib.Path:
@@ -203,17 +197,14 @@ def export_resource_package(
         compression_level: Compression level to use when writing files to the archive.
                            See https://docs.python.org/3/library/zipfile.html#zipfile.ZipFile
         output_path: file path to write package to
-        update_to_current_format: If True attempt auto-conversion to latest format version.
-        update_to_format: update resource to specific major.minor format version; ignoring patch version.
+        update_to_format: update resource to specific "major.minor" or "latest" format version; ignoring patch version.
         weights_priority_order: If given only the first weights format present in the model is included.
                                 If none of the prioritized weights formats is found all are included.
 
     Returns:
         path to zipped BioImage.IO package in BIOIMAGEIO_CACHE_PATH or 'output_path'
     """
-    raw_rd = load_raw_resource_description(
-        source, update_to_current_format=update_to_current_format, update_to_format=update_to_format
-    )
+    raw_rd = load_raw_resource_description(source, update_to_format=update_to_format)
     package_content = get_local_resource_package_content(raw_rd, weights_priority_order)
     if output_path is None:
         package_path = _get_tmp_package_path(raw_rd, weights_priority_order)

--- a/bioimageio/core/resource_io/nodes.py
+++ b/bioimageio/core/resource_io/nodes.py
@@ -172,7 +172,7 @@ class TensorflowSavedModelBundleWeightsEntry(Node, model_raw_nodes.TensorflowSav
 
 
 @dataclass
-class Attachments(Node, model_raw_nodes.Attachments):
+class Attachments(Node, rdf_raw_nodes.Attachments):
     files: Union[_Missing, List[Path]] = missing
     unknown: Union[_Missing, Dict[str, Any]] = missing
 


### PR DESCRIPTION
needs https://github.com/bioimage-io/spec-bioimage-io/pull/335

This PR enables
 - exporting resource packages without format version update
 - export resource package with specified format version

also updates core to sync with latest bioimageio.spec changes (d63d17e11690893b594ea02c3f75b07b863a63c7) 