### PR TITLE
Bump version

### DIFF
--- a/bioimageio/core/VERSION
+++ b/bioimageio/core/VERSION
@@ -1,3 +1,3 @@
 {
-    "version": "0.4.6post0"
+    "version": "0.4.7"
 }


### PR DESCRIPTION
Slight change in API, so I am bumping the patch version. Will also make it easier to pin to the newest version, which is needed e.g. for zerocost notebooks.