### PR TITLE
refactor some io functionality to spec

### DIFF
--- a/bioimageio/core/build_spec/build_model.py
+++ b/bioimageio/core/build_spec/build_model.py
@@ -12,8 +12,8 @@ import bioimageio.spec as spec
 import bioimageio.spec.model as model_spec
 from bioimageio.core import export_resource_package, load_raw_resource_description
 from bioimageio.core.resource_io.nodes import URI
-from bioimageio.core.resource_io.utils import resolve_local_source, resolve_source
 from bioimageio.spec.shared.raw_nodes import ImportableModule, ImportableSourceFile
+from bioimageio.spec.shared.utils import resolve_local_source, resolve_source
 
 try:
     from typing import get_args
@@ -81,6 +81,7 @@ def _get_weights(
     model_kwargs=None,
     tensorflow_version=None,
     opset_version=None,
+    dependencies=None,
     **kwargs,
 ):
     weight_path = resolve_source(original_weight_source, root)
@@ -100,6 +101,8 @@ def _get_weights(
         weights = model_spec.raw_nodes.PytorchStateDictWeightsEntry(
             source=weight_source, sha256=weight_hash, **weight_kwargs
         )
+        if dependencies is not None:
+            weight_kwargs["dependencies"] = _get_dependencies(dependencies, root)
 
     elif weight_type == "onnx":
         if opset_version is None:
@@ -745,6 +748,7 @@ def build_model(
         model_kwargs,
         tensorflow_version=tensorflow_version,
         opset_version=opset_version,
+        dependencies=dependencies,
         **weight_kwargs,
     )
 
@@ -813,8 +817,7 @@ def build_model(
 
     if attachments is not None:
         kwargs["attachments"] = spec.rdf.raw_nodes.Attachments(**attachments)
-    if dependencies is not None:
-        kwargs["dependencies"] = _get_dependencies(dependencies, root)
+
     if maintainers is not None:
         kwargs["maintainers"] = [model_spec.raw_nodes.Maintainer(**m) for m in maintainers]
     if parent is not None:

--- a/bioimageio/core/resource_io/__init__.py
+++ b/bioimageio/core/resource_io/__init__.py
@@ -1,7 +1,9 @@
+import bioimageio.spec
 from .io_ import (
     export_resource_package,
-    load_raw_resource_description,
     load_resource_description,
     save_raw_resource_description,
     serialize_raw_resource_description,
 )
+
+load_raw_resource_description = bioimageio.spec.load_raw_resource_description

--- a/bioimageio/core/resource_io/io_.py
+++ b/bioimageio/core/resource_io/io_.py
@@ -112,7 +112,6 @@ def load_raw_resource_description(
         return source
 
     raw_rd = spec.load_raw_resource_description(source, update_to_format=update_to_format)
-    raw_rd = _replace_relative_paths_for_remote_source(raw_rd, raw_rd.root_path)
     return raw_rd
 
 

--- a/bioimageio/core/resource_io/io_.py
+++ b/bioimageio/core/resource_io/io_.py
@@ -1,118 +1,22 @@
 import os
 import pathlib
-import warnings
-import zipfile
 from copy import deepcopy
-from hashlib import sha256
-from typing import Dict, IO, Optional, Sequence, Tuple, Union
+from typing import Dict, Optional, Sequence, Union
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from marshmallow import missing
 
 from bioimageio import spec
 from bioimageio.core.resource_io.nodes import ResourceDescription
-from bioimageio.spec.io_ import RDF_NAMES, resolve_rdf_source
+from bioimageio.spec import load_raw_resource_description
 from bioimageio.spec.shared import raw_nodes
 from bioimageio.spec.shared.common import BIOIMAGEIO_CACHE_PATH, get_class_name_from_type
 from bioimageio.spec.shared.raw_nodes import ResourceDescription as RawResourceDescription
-from bioimageio.spec.shared.utils import PathToRemoteUriTransformer
 from . import nodes
 from .utils import resolve_raw_resource_description, resolve_source
 
 serialize_raw_resource_description = spec.io_.serialize_raw_resource_description
 save_raw_resource_description = spec.io_.save_raw_resource_description
-
-
-def extract_resource_package(
-    source: Union[os.PathLike, IO, str, bytes, raw_nodes.URI]
-) -> Tuple[dict, str, pathlib.Path]:
-    """extract a zip source to BIOIMAGEIO_CACHE_PATH"""
-    source, source_name, root = resolve_rdf_source(source)
-    if isinstance(root, bytes):
-        raise NotImplementedError("package source was bytes")
-
-    cache_folder = BIOIMAGEIO_CACHE_PATH / "extracted_packages"
-    cache_folder.mkdir(exist_ok=True, parents=True)
-
-    package_path = cache_folder / sha256(str(root).encode("utf-8")).hexdigest()
-    if isinstance(root, raw_nodes.URI):
-        for rdf_name in RDF_NAMES:
-            if (package_path / rdf_name).exists():
-                download = None
-                break
-        else:
-            download = resolve_source(root)
-
-        local_source = download
-    else:
-        download = None
-        local_source = root
-
-    if local_source is not None:
-        with zipfile.ZipFile(local_source) as zf:
-            zf.extractall(package_path)
-
-    for rdf_name in RDF_NAMES:
-        if (package_path / rdf_name).exists():
-            break
-    else:
-        raise FileNotFoundError(f"Missing 'rdf.yaml' in {root} extracted from {download}")
-
-    if download is not None:
-        try:
-            os.remove(download)
-        except Exception as e:
-            warnings.warn(f"Could not remove download {download} due to {e}")
-
-    assert isinstance(package_path, pathlib.Path)
-    return source, source_name, package_path
-
-
-def _replace_relative_paths_for_remote_source(
-    raw_rd: RawResourceDescription, root: Union[pathlib.Path, raw_nodes.URI, bytes]
-) -> RawResourceDescription:
-    if isinstance(root, raw_nodes.URI):
-        # for a remote source relative paths are invalid; replace all relative file paths in source with URLs
-        warnings.warn(
-            f"changing file paths in RDF to URIs due to a remote {root.scheme} source "
-            "(may result in an invalid node)"
-        )
-        raw_rd = PathToRemoteUriTransformer(remote_source=root).transform(raw_rd)
-        root_path = pathlib.Path()  # root_path cannot be URI
-    elif isinstance(root, pathlib.Path):
-        if zipfile.is_zipfile(root):
-            _, _, root_path = extract_resource_package(root)
-        else:
-            root_path = root
-    elif isinstance(root, bytes):
-        raise NotImplementedError("root as bytes (io)")
-    else:
-        raise TypeError(root)
-
-    assert isinstance(root_path, pathlib.Path)
-    raw_rd.root_path = root_path.resolve()
-    return raw_rd
-
-
-def load_raw_resource_description(
-    source: Union[dict, os.PathLike, IO, str, bytes, raw_nodes.URI, RawResourceDescription],
-    update_to_format: Optional[str] = "latest",
-) -> RawResourceDescription:
-    """load a raw python representation from a BioImage.IO resource description file (RDF).
-    Use `load_resource_description` for a more convenient representation.
-
-    Args:
-        source: resource description file (RDF)
-        update_to_format: update resource to specific "major.minor" or "latest" format version; ignoring patch version.
-
-    Returns:
-        raw BioImage.IO resource
-    """
-    if isinstance(source, RawResourceDescription):
-        return source
-
-    raw_rd = spec.load_raw_resource_description(source, update_to_format=update_to_format)
-    return raw_rd
 
 
 def load_resource_description(
@@ -151,7 +55,9 @@ def load_resource_description(
 
 
 def get_local_resource_package_content(
-    source: RawResourceDescription, weights_priority_order: Optional[Sequence[Union[str]]]
+    source: RawResourceDescription,
+    weights_priority_order: Optional[Sequence[Union[str]]],
+    update_to_format: Optional[str] = None,
 ) -> Dict[str, Union[pathlib.Path, str]]:
     """
 
@@ -159,12 +65,13 @@ def get_local_resource_package_content(
         source: raw resource description
         weights_priority_order: If given only the first weights format present in the model is included.
                                 If none of the prioritized weights formats is found all are included.
+        update_to_format: update resource to specific major.minor format version; ignoring patch version.
 
     Returns:
         Package content of local file paths or text content keyed by file names.
 
     """
-    raw_rd = load_raw_resource_description(source)
+    raw_rd = load_raw_resource_description(source, update_to_format=update_to_format)
     package_content = spec.get_resource_package_content(raw_rd, weights_priority_order=weights_priority_order)
 
     local_package_content = {}
@@ -204,7 +111,9 @@ def export_resource_package(
         path to zipped BioImage.IO package in BIOIMAGEIO_CACHE_PATH or 'output_path'
     """
     raw_rd = load_raw_resource_description(source, update_to_format=update_to_format)
-    package_content = get_local_resource_package_content(raw_rd, weights_priority_order)
+    package_content = get_local_resource_package_content(
+        raw_rd, weights_priority_order, update_to_format=update_to_format
+    )
     if output_path is None:
         package_path = _get_tmp_package_path(raw_rd, weights_priority_order)
     else:

--- a/bioimageio/core/resource_io/nodes.py
+++ b/bioimageio/core/resource_io/nodes.py
@@ -43,20 +43,6 @@ class Dependencies(Node, raw_nodes.Dependencies):
 
 
 @dataclass
-class LocalImportableModule(Node, raw_nodes.ImportableModule):
-    """intermediate between raw_nodes.ImportableModule and nodes.ImportedSource. Used by SourceNodeTransformer"""
-
-    root_path: pathlib.Path = missing
-
-
-@dataclass
-class ResolvedImportableSourceFile(Node, raw_nodes.ImportableSourceFile):
-    """intermediate between raw_nodes.ImportableSourceFile and nodes.ImportedSource. Used by SourceNodeTransformer"""
-
-    source_file: pathlib.Path = missing
-
-
-@dataclass
 class CiteEntry(Node, rdf_raw_nodes.CiteEntry):
     pass
 

--- a/bioimageio/core/resource_io/utils.py
+++ b/bioimageio/core/resource_io/utils.py
@@ -2,24 +2,23 @@ import dataclasses
 import importlib.util
 import os
 import pathlib
-import shutil
 import sys
 import typing
-import warnings
-from functools import singledispatch
 from types import ModuleType
-from urllib.request import url2pathname
 
-import requests
-from marshmallow import ValidationError
-from tqdm import tqdm
-
-from bioimageio.spec.shared import fields, raw_nodes
-from bioimageio.spec.shared.common import BIOIMAGEIO_CACHE_PATH
-from bioimageio.spec.shared.utils import GenericRawNode, GenericRawRD, NodeTransformer, NodeVisitor
+from bioimageio.spec.shared import raw_nodes
+from bioimageio.spec.shared.utils import (
+    GenericRawNode,
+    GenericRawRD,
+    GenericResolvedNode,
+    NodeTransformer,
+    NodeVisitor,
+    UriNodeTransformer,
+    resolve_source,
+    source_available,
+)
 from . import nodes
 
-GenericResolvedNode = typing.TypeVar("GenericResolvedNode", bound=nodes.Node)
 GenericNode = typing.Union[GenericRawNode, GenericResolvedNode]
 
 
@@ -48,34 +47,6 @@ class SourceNodeChecker(NodeVisitor):
         self._visit_source(leaf)
 
 
-class UriNodeTransformer(NodeTransformer):
-    def __init__(self, *, root_path: os.PathLike):
-        self.root_path = pathlib.Path(root_path).resolve()
-
-    def transform_URI(self, node: raw_nodes.URI) -> pathlib.Path:
-        local_path = resolve_source(node, root_path=self.root_path)
-        return local_path
-
-    def transform_ImportableSourceFile(
-        self, node: raw_nodes.ImportableSourceFile
-    ) -> nodes.ResolvedImportableSourceFile:
-        return nodes.ResolvedImportableSourceFile(
-            source_file=resolve_source(node.source_file, self.root_path), callable_name=node.callable_name
-        )
-
-    def transform_ImportableModule(self, node: raw_nodes.ImportableModule) -> nodes.LocalImportableModule:
-        return nodes.LocalImportableModule(**dataclasses.asdict(node), root_path=self.root_path)
-
-    def _transform_Path(self, leaf: pathlib.Path):
-        return self.root_path / leaf
-
-    def transform_PosixPath(self, leaf: pathlib.PosixPath) -> pathlib.Path:
-        return self._transform_Path(leaf)
-
-    def transform_WindowsPath(self, leaf: pathlib.WindowsPath) -> pathlib.Path:
-        return self._transform_Path(leaf)
-
-
 class SourceNodeTransformer(NodeTransformer):
     """
     Imports all source callables
@@ -92,7 +63,7 @@ class SourceNodeTransformer(NodeTransformer):
         def __exit__(self, exc_type, exc_value, traceback):
             sys.path.remove(self.path)
 
-    def transform_LocalImportableModule(self, node: nodes.LocalImportableModule) -> nodes.ImportedSource:
+    def transform_LocalImportableModule(self, node: raw_nodes.LocalImportableModule) -> nodes.ImportedSource:
         with self.TemporaryInsertionIntoPythonPath(str(node.root_path)):
             module = importlib.import_module(node.module_name)
 
@@ -105,7 +76,7 @@ class SourceNodeTransformer(NodeTransformer):
         )
 
     @staticmethod
-    def transform_ResolvedImportableSourceFile(node: nodes.ResolvedImportableSourceFile) -> nodes.ImportedSource:
+    def transform_ResolvedImportableSourceFile(node: raw_nodes.ResolvedImportableSourceFile) -> nodes.ImportedSource:
         module_path = resolve_source(node.source_file)
         module_name = f"module_from_source.{module_path.stem}"
         importlib_spec = importlib.util.spec_from_file_location(module_name, module_path)
@@ -137,156 +108,6 @@ class RawNodeTypeTransformer(NodeTransformer):
             return super().generic_transformer(node)
 
 
-@singledispatch  # todo: fix type annotations
-def resolve_source(source, root_path: os.PathLike = pathlib.Path(), output=None):
-    raise TypeError(type(source))
-
-
-@resolve_source.register
-def _resolve_source_uri_node(
-    source: raw_nodes.URI, root_path: os.PathLike = pathlib.Path(), output: typing.Optional[os.PathLike] = None
-) -> pathlib.Path:
-    path_or_remote_uri = resolve_local_source(source, root_path, output)
-    if isinstance(path_or_remote_uri, raw_nodes.URI):
-        local_path = _download_url(path_or_remote_uri, output)
-    elif isinstance(path_or_remote_uri, pathlib.Path):
-        local_path = path_or_remote_uri
-    else:
-        raise TypeError(path_or_remote_uri)
-
-    return local_path
-
-
-@resolve_source.register
-def _resolve_source_str(
-    source: str, root_path: os.PathLike = pathlib.Path(), output: typing.Optional[os.PathLike] = None
-) -> pathlib.Path:
-    return resolve_source(fields.Union([fields.URI(), fields.Path()]).deserialize(source), root_path, output)
-
-
-@resolve_source.register
-def _resolve_source_path(
-    source: pathlib.Path, root_path: os.PathLike = pathlib.Path(), output: typing.Optional[os.PathLike] = None
-) -> pathlib.Path:
-    if not source.is_absolute():
-        source = pathlib.Path(root_path).absolute() / source
-
-    if output is None:
-        return source
-    else:
-        try:
-            shutil.copyfile(source, output)
-        except shutil.SameFileError:  # source and output are identical
-            pass
-        return pathlib.Path(output)
-
-
-@resolve_source.register
-def _resolve_source_resolved_importable_path(
-    source: nodes.ResolvedImportableSourceFile,
-    root_path: os.PathLike = pathlib.Path(),
-    output: typing.Optional[os.PathLike] = None,
-) -> nodes.ResolvedImportableSourceFile:
-    return nodes.ResolvedImportableSourceFile(
-        callable_name=source.callable_name, source_file=resolve_source(source.source_file, root_path, output)
-    )
-
-
-@resolve_source.register
-def _resolve_source_importable_path(
-    source: raw_nodes.ImportableSourceFile,
-    root_path: os.PathLike = pathlib.Path(),
-    output: typing.Optional[os.PathLike] = None,
-) -> nodes.ResolvedImportableSourceFile:
-    return nodes.ResolvedImportableSourceFile(
-        callable_name=source.callable_name, source_file=resolve_source(source.source_file, root_path, output)
-    )
-
-
-@resolve_source.register
-def _resolve_source_list(
-    source: list,
-    root_path: os.PathLike = pathlib.Path(),
-    output: typing.Optional[typing.Sequence[typing.Optional[os.PathLike]]] = None,
-) -> typing.List[pathlib.Path]:
-    assert output is None or len(output) == len(source)
-    return [resolve_source(el, root_path, out) for el, out in zip(source, output or [None] * len(source))]
-
-
-def resolve_local_sources(
-    sources: typing.Sequence[typing.Union[str, os.PathLike, raw_nodes.URI]],
-    root_path: os.PathLike,
-    outputs: typing.Optional[typing.Sequence[os.PathLike]] = None,
-) -> typing.List[typing.Union[pathlib.Path, raw_nodes.URI]]:
-    assert outputs is None or len(outputs) == len(sources)
-    return [resolve_local_source(src, root_path, out) for src, out in zip(sources, outputs)]
-
-
-def resolve_local_source(
-    source: typing.Union[str, os.PathLike, raw_nodes.URI],
-    root_path: os.PathLike,
-    output: typing.Optional[os.PathLike] = None,
-) -> typing.Union[pathlib.Path, raw_nodes.URI]:
-    if isinstance(source, (tuple, list)):
-        return type(source)([resolve_local_source(s, root_path, output) for s in source])
-    elif isinstance(source, os.PathLike) or isinstance(source, str):
-        try:  # source as path from cwd
-            is_path_cwd = pathlib.Path(source).exists()
-        except OSError:
-            is_path_cwd = False
-
-        try:  # source as relative path from root_path
-            path_from_root = pathlib.Path(root_path) / source
-            is_path_rp = (path_from_root).exists()
-        except OSError:
-            is_path_rp = False
-        else:
-            if not is_path_cwd and is_path_rp:
-                source = path_from_root
-
-        if is_path_cwd or is_path_rp:
-            source = pathlib.Path(source)
-            if output is None:
-                return source
-            else:
-                try:
-                    shutil.copyfile(source, output)
-                except shutil.SameFileError:
-                    pass
-                return pathlib.Path(output)
-
-        elif isinstance(source, os.PathLike):
-            raise FileNotFoundError(f"Could neither find {source} nor {pathlib.Path(root_path) / source}")
-
-    if isinstance(source, str):
-        uri = fields.URI().deserialize(source)
-    else:
-        uri = source
-
-    assert isinstance(uri, raw_nodes.URI), uri
-    if uri.scheme == "file":
-        local_path_or_remote_uri = pathlib.Path(url2pathname(uri.path))
-    elif uri.scheme in ("https", "https"):
-        local_path_or_remote_uri = uri
-    else:
-        raise ValueError(f"Unknown uri scheme {uri.scheme}")
-
-    return local_path_or_remote_uri
-
-
-def source_available(source: typing.Union[pathlib.Path, raw_nodes.URI], root_path: pathlib.Path) -> bool:
-    local_path_or_remote_uri = resolve_local_source(source, root_path)
-    if isinstance(local_path_or_remote_uri, raw_nodes.URI):
-        response = requests.head(str(local_path_or_remote_uri))
-        available = response.status_code == 200
-    elif isinstance(local_path_or_remote_uri, pathlib.Path):
-        available = local_path_or_remote_uri.exists()
-    else:
-        raise TypeError(local_path_or_remote_uri)
-
-    return available
-
-
 def all_sources_available(
     node: typing.Union[GenericNode, list, tuple, dict], root_path: os.PathLike = pathlib.Path()
 ) -> bool:
@@ -296,41 +117,6 @@ def all_sources_available(
         return False
     else:
         return True
-
-
-def _download_url(uri: raw_nodes.URI, output: typing.Optional[os.PathLike] = None) -> pathlib.Path:
-    if output is not None:
-        local_path = pathlib.Path(output)
-    else:
-        # todo: proper caching
-        local_path = BIOIMAGEIO_CACHE_PATH / uri.scheme / uri.authority / uri.path.strip("/") / uri.query
-
-    if local_path.exists():
-        warnings.warn(f"found cached {local_path}. Skipping download of {uri}.")
-    else:
-        local_path.parent.mkdir(parents=True, exist_ok=True)
-
-        try:
-            # download with tqdm adapted from:
-            # https://github.com/shaypal5/tqdl/blob/189f7fd07f265d29af796bee28e0893e1396d237/tqdl/core.py
-            # Streaming, so we can iterate over the response.
-            r = requests.get(str(uri), stream=True)
-            # Total size in bytes.
-            total_size = int(r.headers.get("content-length", 0))
-            block_size = 1024  # 1 Kibibyte
-            t = tqdm(total=total_size, unit="iB", unit_scale=True, desc=local_path.name)
-            with local_path.open("wb") as f:
-                for data in r.iter_content(block_size):
-                    t.update(len(data))
-                    f.write(data)
-            t.close()
-            if total_size != 0 and t.n != total_size:
-                # todo: check more carefully and raise on real issue
-                warnings.warn("Download does not have expected size.")
-        except Exception as e:
-            raise RuntimeError(f"Failed to download {uri} ({e})")
-
-    return local_path
 
 
 def resolve_raw_resource_description(raw_rd: GenericRawRD, nodes_module: typing.Any) -> GenericResolvedNode:

--- a/tests/resource_io/test_load_rdf.py
+++ b/tests/resource_io/test_load_rdf.py
@@ -1,10 +1,8 @@
 import os.path
 import pathlib
 from pathlib import Path
-from tempfile import NamedTemporaryFile
 
 import pytest
-from marshmallow import ValidationError
 
 from bioimageio.core.resource_io.utils import resolve_source
 
@@ -80,7 +78,7 @@ def test_load_remote_model_with_folders():
 
     # todo: point to real model with nested folders, not this temporary sandbox one
     rdf_url = "https://sandbox.zenodo.org/record/892199/files/rdf.yaml"
-    raw_model = load_raw_resource_description(rdf_url)
+    raw_model = load_raw_resource_description(rdf_url, update_to_format="latest")
     assert isinstance(raw_model, raw_nodes.Model)
     model = load_resource_description(rdf_url)
     assert isinstance(model, nodes.Model)


### PR DESCRIPTION
needs https://github.com/bioimage-io/spec-bioimage-io/pull/343

syncs `load_raw_resource_description` with `bioimageio.spec.load_raw_resource_description` (`load_raw_resource_description` `s default for `update_to_format` is not overwritten anymore to 'latest', instead where it's called with `update_to_format='latest'` 

todo:
 - [x] update build_spec