### PR TITLE
Fix test-resource

### DIFF
--- a/bioimageio/core/__main__.py
+++ b/bioimageio/core/__main__.py
@@ -5,6 +5,7 @@ import sys
 from glob import glob
 
 from pathlib import Path
+from pprint import pprint
 from typing import List, Optional
 
 import typer
@@ -110,7 +111,7 @@ def test_model(
         ret_code = 0
     else:
         print(f"Model test for {model_rdf} using {weight_format} weight format has FAILED!")
-        print(summary)
+        pprint(summary)
         ret_code = 1
     sys.exit(ret_code)
 
@@ -138,7 +139,7 @@ def test_resource(
         ret_code = 0
     else:
         print(f"Resource test for {rdf} has FAILED!")
-        print(summary)
+        pprint(summary)
         ret_code = 1
     sys.exit(ret_code)
 

--- a/bioimageio/core/resource_io/nodes.py
+++ b/bioimageio/core/resource_io/nodes.py
@@ -63,7 +63,7 @@ class Badge(Node, rdf_raw_nodes.Badge):
 
 
 @dataclass
-class RDF(rdf_raw_nodes.RDF, Node):
+class RDF(rdf_raw_nodes.RDF, ResourceDescription):
     badges: Union[_Missing, List[Badge]] = missing
     covers: Union[_Missing, List[Path]] = missing
 
@@ -79,7 +79,7 @@ class ModelParent(Node, model_raw_nodes.ModelParent):
 
 
 @dataclass
-class Collection(RDF, collection_raw_nodes.Collection):
+class Collection(collection_raw_nodes.Collection, RDF):
     pass
 
 
@@ -174,7 +174,7 @@ WeightsEntry = Union[
 
 
 @dataclass
-class Model(model_raw_nodes.Model, RDF, Node):
+class Model(model_raw_nodes.Model, RDF):
     authors: List[Author] = missing
     maintainers: Union[_Missing, List[Maintainer]] = missing
     test_inputs: List[Path] = missing


### PR DESCRIPTION
fixes #203

Incorrent node inheritance caused the loaded resource to be reloaded without accounting for resolved paths, etc... 
Correct node inheritance fixes this by correctly detecting if a resource is already loaded. 