### PR TITLE
Infer `.pt` weight file as `torchscript`

### DIFF
--- a/bioimageio/core/build_spec/build_model.py
+++ b/bioimageio/core/build_spec/build_model.py
@@ -41,7 +41,9 @@ def _get_hash(path):
 
 def _infer_weight_type(path):
     ext = os.path.splitext(path)[-1]
-    if ext in (".pt", ".pth", ".torch"):
+    if ext == ".pt":
+        return "torchscript"
+    if ext in (".pth", ".torch"):
         return "pytorch_state_dict"
     elif ext == ".onnx":
         return "onnx"


### PR DESCRIPTION
`*.pt` file should be the extension for torchscript according to the documentation of pytorch: https://pytorch.org/tutorials/beginner/Intro_to_TorchScript_tutorial.html#saving-and-loading-models