### PR TITLE
Fix torch to onnx conversion

### DIFF
--- a/bioimageio/core/weight_converter/torch/onnx.py
+++ b/bioimageio/core/weight_converter/torch/onnx.py
@@ -58,7 +58,6 @@ def convert_weights_to_onnx(
                 output_path,
                 verbose=verbose,
                 opset_version=opset_version,
-                example_outputs=expected_outputs,
             )
         else:
             raise NotImplementedError

--- a/dev/environment-torch.yaml
+++ b/dev/environment-torch.yaml
@@ -6,12 +6,12 @@ dependencies:
   - black
   - bioimageio.spec >=0.4.4
   - conda-build
-  - h5py >=2.10,<2.11
+  - h5py
   - mypy
   - pip
   - pytest
   - python >=3.7
   - xarray
-  - pytorch <1.10
+  - pytorch
   - onnxruntime
   - tifffile


### PR DESCRIPTION
- remove torch version pinning to catch incompatibilities with newer versions
- Fix torch to onnx conversion, which failed due to https://github.com/pytorch/pytorch/pull/67809
