### PR TITLE
Extend test resources

### DIFF
--- a/bioimageio/core/__main__.py
+++ b/bioimageio/core/__main__.py
@@ -142,6 +142,7 @@ def test_model(
         devices=devices,
         decimal=decimal,
     )
+    print(f"\ntesting model {model_rdf}...")
     ret_code = _log_test_summaries(summaries, f"\n{{icon}} Model {model_rdf} {{result}}")
     sys.exit(ret_code)
 
@@ -164,6 +165,7 @@ def test_resource(
     summaries = resource_tests.test_resource(
         rdf, weight_format=None if weight_format is None else weight_format.value, devices=devices, decimal=decimal
     )
+    print(f"\ntesting {rdf}...")
     ret_code = _log_test_summaries(summaries, f"{{icon}} Resource test for {rdf} has {{result}}")
     sys.exit(ret_code)
 

--- a/bioimageio/core/__main__.py
+++ b/bioimageio/core/__main__.py
@@ -2,6 +2,7 @@ import enum
 import json
 import os
 import sys
+import warnings
 from glob import glob
 
 from pathlib import Path
@@ -22,12 +23,16 @@ except ImportError:
     from typing_extensions import get_args  # type: ignore
 
 try:
-    from bioimageio.core.weight_converter import torch as torch_converter
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        from bioimageio.core.weight_converter import torch as torch_converter
 except ImportError:
     torch_converter = None
 
 try:
-    from bioimageio.core.weight_converter import keras as keras_converter
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        from bioimageio.core.weight_converter import keras as keras_converter
 except ImportError:
     keras_converter = None
 

--- a/bioimageio/core/build_spec/add_weights.py
+++ b/bioimageio/core/build_spec/add_weights.py
@@ -38,6 +38,11 @@ def add_weights(
         attachments: extra weight specific attachments.
     """
     model = load_raw_resource_description(model)
+    if not isinstance(model.root_path, Path):
+        # ensure model is available locally
+        model = load_raw_resource_description(export_resource_package(model))
+
+    assert isinstance(model.root_path, Path), model.root_path
 
     # copy the weight path to the input model's root, otherwise it will
     # not be found when packaging the new model

--- a/bioimageio/core/common.py
+++ b/bioimageio/core/common.py
@@ -1,0 +1,5 @@
+from bioimageio.spec.shared.common import ValidationSummary
+
+
+class TestSummary(ValidationSummary):
+    bioimageio_core_version: str

--- a/bioimageio/core/prediction.py
+++ b/bioimageio/core/prediction.py
@@ -129,20 +129,23 @@ def _predict_with_tiling_impl(
 
 def predict(
     prediction_pipeline: PredictionPipeline,
-    inputs: Union[xr.DataArray, List[xr.DataArray], Tuple[xr.DataArray]],
+    inputs: Union[
+        xr.DataArray, List[xr.DataArray], Tuple[xr.DataArray], np.ndarray, List[np.ndarray], Tuple[np.ndarray]
+    ],
 ) -> List[xr.DataArray]:
     """Run prediction for a single set of input(s) with a bioimage.io model
 
     Args:
         prediction_pipeline: the prediction pipeline for the input model.
-        inputs: the input(s) for this model represented as xarray data.
+        inputs: the input(s) for this model represented as xarray data or numpy nd array.
     """
     if not isinstance(inputs, (tuple, list)):
         inputs = [inputs]
 
     assert len(inputs) == len(prediction_pipeline.input_specs)
     tagged_data = [
-        xr.DataArray(ipt, dims=ipt_spec.axes) for ipt, ipt_spec in zip(inputs, prediction_pipeline.input_specs)
+        ipt if isinstance(ipt, xr.DataArray) else xr.DataArray(ipt, dims=ipt_spec.axes)
+        for ipt, ipt_spec in zip(inputs, prediction_pipeline.input_specs)
     ]
     return prediction_pipeline.forward(*tagged_data)
 

--- a/bioimageio/core/resource_tests.py
+++ b/bioimageio/core/resource_tests.py
@@ -98,7 +98,7 @@ def _test_resource_urls(rd: ResourceDescription) -> TestSummary:
         bioimageio_spec_version=bioimageio_spec_version,
         bioimageio_core_version=bioimageio_core_version,
         nested_errors=None,
-        source_name=rd.id if hasattr(rd, "id") else rd.name,
+        source_name=rd.id or rd.id or rd.name if hasattr(rd, "id") else rd.name,
         warnings={"SourceNodeChecker": [str(w.message) for w in all_warnings]} if all_warnings else {},
     )
 
@@ -120,7 +120,7 @@ def _test_model_documentation(rd: ResourceDescription) -> TestSummary:
             traceback=None,
             bioimageio_spec_version=bioimageio_spec_version,
             bioimageio_core_version=bioimageio_core_version,
-            source_name=rd.id if hasattr(rd, "id") else rd.name,
+            source_name=rd.id or rd.name if hasattr(rd, "id") else rd.name,
             warnings={"documentation": wrn} if wrn else {},
         )
 
@@ -176,7 +176,7 @@ def _test_model_inference(model: Model, weight_format: str, devices: Optional[Li
         bioimageio_spec_version=bioimageio_spec_version,
         bioimageio_core_version=bioimageio_core_version,
         warnings={},
-        source_name=model.id,
+        source_name=model.id or model.name,
     )
 
 
@@ -227,7 +227,7 @@ def _test_expected_resource_type(rd: ResourceDescription, expected_type: str) ->
         status="passed" if has_expected_type else "failed",
         error=f"expected type {expected_type}, found {rd.type}",
         traceback=None,
-        source_name=rd.id if hasattr(rd, "id") else rd.name,
+        source_name=rd.id or rd.name if hasattr(rd, "id") else rd.name,
     )
 
 

--- a/bioimageio/core/resource_tests.py
+++ b/bioimageio/core/resource_tests.py
@@ -166,7 +166,7 @@ def test_resource(
     test_name: str = "load resource description"
 
     if isinstance(rdf, (URI, os.PathLike)):
-        source_name = rdf
+        source_name = str(rdf)
     elif isinstance(rdf, str):
         source_name = rdf[:120]
     else:

--- a/bioimageio/core/resource_tests.py
+++ b/bioimageio/core/resource_tests.py
@@ -134,7 +134,7 @@ def test_model_documentation(rd: ResourceDescription) -> TestSummary:
     doc_path: Path = resolve_source(rd.documentation, root_path=rd.root_path)
     doc = doc_path.read_text()
     wrn = ""
-    if not re.fullmatch("#.*[vV]alidation", doc):
+    if not re.match("#.*[vV]alidation", doc):
         wrn = "No '# Validation' (sub)section found."
 
     return dict(

--- a/bioimageio/core/resource_tests.py
+++ b/bioimageio/core/resource_tests.py
@@ -137,7 +137,7 @@ def _test_model_inference(model: Model, weight_format: str, devices: Optional[Li
             assert len(inputs) == len(model.inputs)  # should be checked by validation
             input_shapes = {}
             for idx, (ipt, ipt_spec) in enumerate(zip(inputs, model.inputs)):
-                if not _validate_input_shape(tuple(ipt.shape), ipt_spec.shape):
+                if not check_input_shape(tuple(ipt.shape), ipt_spec.shape):
                     raise ValidationError(
                         f"Shape {tuple(ipt.shape)} of test input {idx} '{ipt_spec.name}' does not match "
                         f"input shape description: {ipt_spec.shape}."
@@ -146,7 +146,7 @@ def _test_model_inference(model: Model, weight_format: str, devices: Optional[Li
 
             assert len(expected) == len(model.outputs)  # should be checked by validation
             for idx, (out, out_spec) in enumerate(zip(expected, model.outputs)):
-                if not _validate_output_shape(tuple(out.shape), out_spec.shape, input_shapes):
+                if not check_output_shape(tuple(out.shape), out_spec.shape, input_shapes):
                     error = (error or "") + (
                         f"Shape {tuple(out.shape)} of test output {idx} '{out_spec.name}' does not match "
                         f"output shape description: {out_spec.shape}."

--- a/bioimageio/core/resource_tests.py
+++ b/bioimageio/core/resource_tests.py
@@ -25,6 +25,7 @@ from bioimageio.core.resource_io.utils import SourceNodeChecker
 from bioimageio.spec import __version__ as bioimageio_spec_version
 from bioimageio.spec.model.raw_nodes import WeightsFormat
 from bioimageio.spec.shared import resolve_source
+from bioimageio.spec.shared.common import ValidationWarning
 from bioimageio.spec.shared.raw_nodes import ResourceDescription as RawResourceDescription
 
 
@@ -126,6 +127,8 @@ def _test_model_documentation(rd: ResourceDescription) -> TestSummary:
 
 
 def _test_model_inference(model: Model, weight_format: str, devices: Optional[List[str]], decimal: int) -> TestSummary:
+    error: Optional[str] = None
+    tb: Optional = None
     with warnings.catch_warnings(record=True) as all_warnings:
         try:
             inputs = [np.load(str(in_path)) for in_path in model.test_inputs]
@@ -175,7 +178,7 @@ def _test_model_inference(model: Model, weight_format: str, devices: Optional[Li
         traceback=tb,
         bioimageio_spec_version=bioimageio_spec_version,
         bioimageio_core_version=bioimageio_core_version,
-        warnings={},
+        warnings=ValidationWarning.get_warning_summary(all_warnings),
         source_name=model.id or model.name,
     )
 

--- a/tests/build_spec/test_add_weights.py
+++ b/tests/build_spec/test_add_weights.py
@@ -31,9 +31,11 @@ def _test_add_weights(model, tmp_path, base_weights, added_weights, **kwargs):
         assert weight.source.exists()
 
     test_res = _test_model(out_path, added_weights)
-    assert all([s["status"] == "passed" for s in test_res])
+    failed = [s for s in test_res if s["status"] != "passed"]
+    assert not failed, failed
     test_res = _test_model(out_path)
-    assert all([s["status"] == "passed" for s in test_res])
+    failed = [s for s in test_res if s["status"] != "passed"]
+    assert not failed, failed
 
     # make sure the weights were cleaned from the cwd
     assert not os.path.exists(os.path.split(weight_path)[1])

--- a/tests/build_spec/test_add_weights.py
+++ b/tests/build_spec/test_add_weights.py
@@ -31,8 +31,9 @@ def _test_add_weights(model, tmp_path, base_weights, added_weights, **kwargs):
         assert weight.source.exists()
 
     test_res = _test_model(out_path, added_weights)
+    assert all([s["status"] == "passed" for s in test_res])
     test_res = _test_model(out_path)
-    assert test_res["error"] is None
+    assert all([s["status"] == "passed" for s in test_res])
 
     # make sure the weights were cleaned from the cwd
     assert not os.path.exists(os.path.split(weight_path)[1])

--- a/tests/build_spec/test_build_spec.py
+++ b/tests/build_spec/test_build_spec.py
@@ -152,7 +152,7 @@ def _test_build_spec(
 
     # test inference for the model to ensure that the weights were written correctly
     test_res = _test_model(out_path)
-    assert test_res["error"] is None
+    assert all([s["status"] == "passed" for s in test_res])
 
 
 def test_build_spec_pytorch(any_torch_model, tmp_path):
@@ -209,7 +209,7 @@ def test_build_spec_training_data2(unet2d_nuclei_broad_model, tmp_path):
 
 
 def test_build_spec_parent1(unet2d_nuclei_broad_model, tmp_path):
-    parent = {"uri": "https:/my-parent-model.org"}
+    parent = {"uri": "https://doi.org/10.5281/zenodo.5764892"}
     _test_build_spec(unet2d_nuclei_broad_model, tmp_path / "model.zip", "torchscript", parent=parent)
 
 

--- a/tests/test_resource_tests/test_test_model.py
+++ b/tests/test_resource_tests/test_test_model.py
@@ -46,7 +46,7 @@ def test_validation_section_warning(unet2d_nuclei_broad_model, tmp_path: pathlib
 
     model = load_resource_description(unet2d_nuclei_broad_model)
 
-    summary = test_resource(model)[1]
+    summary = test_resource(model)[2]
     assert summary["name"] == "Test documentation completeness."
     assert summary["warnings"] == {"documentation": "No '# Validation' (sub)section found."}
     assert summary["status"] == "passed"
@@ -54,7 +54,7 @@ def test_validation_section_warning(unet2d_nuclei_broad_model, tmp_path: pathlib
     doc_with_validation = tmp_path / "doc.md"
     doc_with_validation.write_text("# Validation\nThis is a section about how to validate the model on new data")
     model.documentation = doc_with_validation
-    summary = test_resource(model)[1]
+    summary = test_resource(model)[2]
     assert summary["name"] == "Test documentation completeness."
     assert summary["warnings"] == {}
     assert summary["status"] == "passed"

--- a/tests/test_resource_tests/test_test_model.py
+++ b/tests/test_resource_tests/test_test_model.py
@@ -1,7 +1,7 @@
 def test_error_for_wrong_shape(stardist_wrong_shape):
     from bioimageio.core.resource_tests import test_model
 
-    summary = test_model(stardist_wrong_shape)
+    summary = test_model(stardist_wrong_shape)[0]
     expected_error_message = (
         "Shape (1, 512, 512, 33) of test output 0 'output' does not match output shape description: "
         "ImplicitOutputShape(reference_tensor='input', "
@@ -13,7 +13,7 @@ def test_error_for_wrong_shape(stardist_wrong_shape):
 def test_error_for_wrong_shape2(stardist_wrong_shape2):
     from bioimageio.core.resource_tests import test_model
 
-    summary = test_model(stardist_wrong_shape2)
+    summary = test_model(stardist_wrong_shape2)[0]
     expected_error_message = (
         "Shape (1, 512, 512, 1) of test input 0 'input' does not match input shape description: "
         "ParametrizedInputShape(min=[1, 80, 80, 1], step=[0, 17, 17, 0])."
@@ -24,12 +24,12 @@ def test_error_for_wrong_shape2(stardist_wrong_shape2):
 def test_test_model(any_model):
     from bioimageio.core.resource_tests import test_model
 
-    summary = test_model(any_model)
+    summary = test_model(any_model)[0]
     assert summary["error"] is None
 
 
 def test_test_resource(any_model):
     from bioimageio.core.resource_tests import test_resource
 
-    summary = test_resource(any_model)
+    summary = test_resource(any_model)[0]
     assert summary["error"] is None

--- a/tests/test_resource_tests/test_test_model.py
+++ b/tests/test_resource_tests/test_test_model.py
@@ -1,3 +1,8 @@
+import pathlib
+
+from bioimageio.spec.shared import yaml
+
+
 def test_error_for_wrong_shape(stardist_wrong_shape):
     from bioimageio.core.resource_tests import test_model
 
@@ -33,3 +38,23 @@ def test_test_resource(any_model):
 
     summary = test_resource(any_model)[0]
     assert summary["error"] is None
+
+
+def test_validation_section_warning(unet2d_nuclei_broad_model, tmp_path: pathlib.Path):
+    from bioimageio.core.resource_tests import test_resource
+    from bioimageio.core import load_resource_description
+
+    model = load_resource_description(unet2d_nuclei_broad_model)
+
+    summary = test_resource(model)[1]
+    assert summary["name"] == "Test documentation completeness."
+    assert summary["warnings"] == {"documentation": "No '# Validation' (sub)section found."}
+    assert summary["status"] == "passed"
+
+    doc_with_validation = tmp_path / "doc.md"
+    doc_with_validation.write_text("# Validation\nThis is a section about how to validate the model on new data")
+    model.documentation = doc_with_validation
+    summary = test_resource(model)[1]
+    assert summary["name"] == "Test documentation completeness."
+    assert summary["warnings"] == {}
+    assert summary["status"] == "passed"

--- a/tests/test_resource_tests/test_test_model.py
+++ b/tests/test_resource_tests/test_test_model.py
@@ -1,12 +1,10 @@
 import pathlib
 
-from bioimageio.spec.shared import yaml
-
 
 def test_error_for_wrong_shape(stardist_wrong_shape):
     from bioimageio.core.resource_tests import test_model
 
-    summary = test_model(stardist_wrong_shape)[0]
+    summary = test_model(stardist_wrong_shape)[-1]
     expected_error_message = (
         "Shape (1, 512, 512, 33) of test output 0 'output' does not match output shape description: "
         "ImplicitOutputShape(reference_tensor='input', "
@@ -18,7 +16,7 @@ def test_error_for_wrong_shape(stardist_wrong_shape):
 def test_error_for_wrong_shape2(stardist_wrong_shape2):
     from bioimageio.core.resource_tests import test_model
 
-    summary = test_model(stardist_wrong_shape2)[0]
+    summary = test_model(stardist_wrong_shape2)[-1]
     expected_error_message = (
         "Shape (1, 512, 512, 1) of test input 0 'input' does not match input shape description: "
         "ParametrizedInputShape(min=[1, 80, 80, 1], step=[0, 17, 17, 0])."
@@ -29,15 +27,15 @@ def test_error_for_wrong_shape2(stardist_wrong_shape2):
 def test_test_model(any_model):
     from bioimageio.core.resource_tests import test_model
 
-    summary = test_model(any_model)[0]
-    assert summary["error"] is None
+    summary = test_model(any_model)
+    assert all([s["status"] for s in summary])
 
 
 def test_test_resource(any_model):
     from bioimageio.core.resource_tests import test_resource
 
-    summary = test_resource(any_model)[0]
-    assert summary["error"] is None
+    summary = test_resource(any_model)
+    assert all([s["status"] for s in summary])
 
 
 def test_validation_section_warning(unet2d_nuclei_broad_model, tmp_path: pathlib.Path):


### PR DESCRIPTION
`test_resource` and `test_model` now include
- test for availability of all paths or urls (can cause failure)
- test for a '# validation' section in model documentation (always passes, only generates warning)