### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     ],
     packages=find_namespace_packages(exclude=["tests"]),  # Required
     install_requires=[
-        "bioimageio.spec>=0.4.5",
+        "bioimageio.spec==0.4.8",
         "imageio>=2.5",
         "numpy",
         "ruamel.yaml",

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     ],
     packages=find_namespace_packages(exclude=["tests"]),  # Required
     install_requires=[
-        "bioimageio.spec==0.4.8",
+        "bioimageio.spec==0.4.8.*",
         "imageio>=2.5",
         "numpy",
         "ruamel.yaml",


### PR DESCRIPTION
we ought to pin bioimageio.spec more closely due to lack of forward compatibility. 
i.e. installing an older version of core will install the newest spec version.

This will add to the list of checkboxes for a new core release, but should make the released versions more reliable.