### PR TITLE
add_weights example in model_creation notebook

### DIFF
--- a/example/model_creation.ipynb
+++ b/example/model_creation.ipynb
@@ -31,7 +31,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "07ef310c",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "import os\n",
@@ -42,7 +44,7 @@
     "import numpy as np\n",
     "import torch\n",
     "import torch.nn as nn\n",
-    "from bioimageio.core.build_spec import build_model"
+    "from bioimageio.core.build_spec import build_model, add_weights"
    ]
   },
   {
@@ -83,7 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# create test data for this model: an input image and a output image\n",
+    "# create test data for this model: an input image and an output image\n",
     "# this data will be used for model test runs to ensure the model runs correctly and that the expected output can be reproduced\n",
     "# NOTE: if you have pre-and-post-processing in your model (see the more advanced models for an example)\n",
     "# you will need to save the input BEFORE preprocessing and the output AFTER postprocessing\n",
@@ -362,15 +364,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# load the new model from the zipped package, run prediction and check the result\n",
+    "new_model = bioimageio.core.load_resource_description(zip_path)\n",
+    "\n",
     "# `convert_weigths_to_pytorch_script` creates torchscript weigths based on the weights loaded from pytorch_state_dict\n",
     "from bioimageio.core.weight_converter.torch import convert_weights_to_torchscript\n",
     "\n",
     "# the path to save the newly created torchscript weights\n",
-    "weight_path = os.path.join(model_root, \"weights.torchscript\")\n",
-    "convert_weights_to_torchscript(new_model, weight_path)\n",
-    "\n",
-    "# the path to save the new model with torchscript weights\n",
-    "zip_path = f\"{model_root}/new_model2.zip\""
+    "weight_path_ts = os.path.join(model_root, \"weights.torchscript\")\n",
+    "convert_weights_to_torchscript(new_model, weight_path_ts)\n"
    ]
   },
   {
@@ -380,16 +382,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# build the new model with torchscript weights and with the deepimagej config\n",
+    "# build the new model with the original pytorch_state_dict weights and with the deepimagej config\n",
     "# we don't apply the post-processing here\n",
-    "new_model_raw = build_model(\n",
-    "    weight_uri=weight_path,\n",
-    "    weight_type=\"torchscript\",\n",
+    "\n",
+    "# the path to save the new model with torchscript weights\n",
+    "temp_zip_path = f\"{model_root}/new_model3.zip\"\n",
+    "\n",
+    "_ = build_model(    \n",
+    "    weight_uri=weight_file,\n",
+    "    weight_type=\"pytorch_state_dict\",\n",
+    "    architecture=model_source,\n",
+    "    model_kwargs=model_resource.weights[\"pytorch_state_dict\"].kwargs,\n",
     "    test_inputs=model_resource.test_inputs,\n",
     "    test_outputs=model_resource.test_outputs,\n",
     "    input_axes=input_axes,\n",
     "    output_axes=output_axes,\n",
-    "    output_path=zip_path,\n",
+    "    output_path=temp_zip_path,\n",
     "    name=name,\n",
     "    description=\"nucleus segmentation model with thresholding\",\n",
     "    authors=[{\"name\": \"Jane Doe\"}],\n",
@@ -399,9 +407,52 @@
     "    tags=[\"nucleus-segmentation\"],\n",
     "    cite=cite,\n",
     "    parent=parent,\n",
-    "    preprocessing=preprocessing,\n",
+    "    preprocessing=None,\n",
     "    add_deepimagej_config=True\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d01f39c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add the new torchsript weights in the rdf.yaml, in addition to the original pytorch_state_dict\n",
+    "# Note: this will only work if the weights are added in the order presented here:\n",
+    "    # 1. build_model with the pytorch_state_dict (original)\n",
+    "    # 2. add_weights with the torchscript weights (new)\n",
+    "    # possible reason: cache has the info of original weights only\n",
+    "\n",
+    "final_zip_path = f\"{model_root}/new_model_added_weigths.zip\"\n",
+    "\n",
+    "_=add_weights(\n",
+    "    model=temp_zip_path,\n",
+    "    output_path=final_zip_path,\n",
+    "    weight_uri=weight_path_ts,\n",
+    "    weight_type=\"torchscript\",\n",
+    "    pytorch_version = torch.__version__\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1097b0bb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Test both weight types to see that they produce the same test results\n",
+    "\n",
+    "for wf in [\"torchscript\", \"pytorch_state_dict\"]:\n",
+    "    print(\"\\n-- Testing for weight format {} ----------------------------\".format(wf))\n",
+    "    res = bioimageio.core.resource_tests.test_model(final_zip_path,\n",
+    "                                                    weight_format=wf,\n",
+    "                                                    decimal=6) # put many decimals so that the test fails\n",
+    "    for r in res:\n",
+    "        print(\"- {}: \\t {}\".format(r[\"name\"], r[\"status\"]))\n",
+    "    print(r[\"error\"]) # print the disagreeing error in decimals (same for both weight types)"
    ]
   },
   {
@@ -412,11 +463,19 @@
    "outputs": [],
    "source": [
     "# load the new model from the zipped package, run prediction and check the result\n",
-    "new_model = bioimageio.core.load_resource_description(zip_path)\n",
+    "new_model = bioimageio.core.load_resource_description(final_zip_path)\n",
     "with bioimageio.core.create_prediction_pipeline(new_model) as prediction_pipeline:\n",
     "    prediction = prediction_pipeline(input_array)[0]\n",
     "show_images(input_image, prediction, names=[\"input\", \"binarized-prediction\"])"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19466e19",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -435,7 +494,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Adress issue #311

Example of use of the `add_weights` function in the model_creation notebook. I modified the 3rd example.

It takes an original model with `pytorch_state_dict weights`, builds the rdf.yaml with the deepimagej configuration, 
and then adds the information of the `torchscript` weights. 
Finally, it tests to see that both weight types produce the same results.