### PR TITLE
TF: prevent model compilation

### DIFF
--- a/bioimageio/core/prediction_pipeline/_model_adapters/_tensorflow_model_adapter.py
+++ b/bioimageio/core/prediction_pipeline/_model_adapters/_tensorflow_model_adapter.py
@@ -29,7 +29,7 @@ class TensorflowModelAdapterBase(ModelAdapter):
     def _load_model(self, weight_file):
         weight_file = self.require_unzipped(weight_file)
         if self.use_keras_api:
-            return tf.keras.models.load_model(weight_file)
+            return tf.keras.models.load_model(weight_file, compile=False)
         else:
             # NOTE in tf1 the model needs to be loaded inside of the session, so we cannot preload the model
             return str(weight_file)


### PR DESCRIPTION
Hi!

I ran into an issue with N2V: since it uses a custom loss, loading the model using `tf.keras.models.load_model` throws an error when the model has been compiled and saved as a `SavedModel`. The same method is used when validating a `SaveModel` in `bioimageio.core`.

One way around this is to pass `compile=False` ([see that line](https://github.com/jdeschamps/core-bioimage-io-python/blob/d2505c47a826ec68a1576eab56172efd9f947459/bioimageio/core/prediction_pipeline/_model_adapters/_tensorflow_model_adapter.py#L32)), avoiding the compilation of the model after loading. If I am not mistaken, the compilation is only required for training (compiling loss, metrics, optimizer etc.), it is not needed for the purpose of the bioimage.io model validation (inference). 

The model can still be loaded and compiled by users provided they have access to the custom methods. I tested that with N2V and it solves the error.

Happy to know more if there are things that I overlooked!