### PR TITLE
CI update: use micromamba instead of miniconda

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,14 +29,12 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
-    - name: install dependencies
-      uses: conda-incubator/setup-miniconda@v2
+    - name: Install Conda environment with Micromamba
+      uses: mamba-org/provision-with-micromamba@main
       with:
-        auto-update-conda: true
-        channel-priority: strict
-        activate-environment: bio-core-torch
         environment-file: dev/environment-torch.yaml
-        python-version: ${{ matrix.python-version }}
+        extra-specs: |
+          python=${{ matrix.python-version }}
     - name: additional setup
       shell: bash -l {0}
       run: pip install --no-deps -e .
@@ -51,18 +49,16 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
-    - name: install dependencies
-      uses: conda-incubator/setup-miniconda@v2
+    - name: Install Conda environment with Micromamba
+      uses: mamba-org/provision-with-micromamba@main
       with:
-        auto-update-conda: true
-        channel-priority: strict
-        activate-environment: bio-core-torch
         environment-file: dev/environment-torch.yaml
-        python-version: ${{ matrix.python-version }}
+        extra-specs: |
+          python=${{ matrix.python-version }}
     - name: additional setup
       shell: bash -l {0}
       run: |
-        conda remove --force bioimageio.spec
+        mamba remove --force bioimageio.spec
         pip install --no-deps git+https://github.com/bioimage-io/spec-bioimage-io
         pip install --no-deps -e .
     - name: pytest-base-bioimage-spec-main
@@ -76,20 +72,17 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
-    - name: install dependencies
-      uses: conda-incubator/setup-miniconda@v2
+    - name: Install Conda environment with Micromamba
+      uses: mamba-org/provision-with-micromamba@main
       with:
-        auto-update-conda: true
-        # we need mamba to resolve environment-tf
-        mamba-version: "*"
-        channel-priority: flexible
-        activate-environment: bio-core-tf
         environment-file: dev/environment-tf.yaml
-        python-version: ${{ matrix.python-version }}
+        channel-priority: flexible
+        extra-specs: |
+          python=${{ matrix.python-version }}
     - name: additional setup
       shell: bash -l {0}
       run: |
-        conda remove --force bioimageio.spec
+        mamba remove --force bioimageio.spec
         pip install --no-deps git+https://github.com/bioimage-io/spec-bioimage-io
         pip install --no-deps -e .
     - name: pytest-base-bioimage-spec-tf
@@ -103,20 +96,17 @@ jobs:
         python-version: [3.7]
     steps:
     - uses: actions/checkout@v2
-    - name: install dependencies
-      uses: conda-incubator/setup-miniconda@v2
+    - name: Install Conda environment with Micromamba
+      uses: mamba-org/provision-with-micromamba@main
       with:
-        auto-update-conda: true
-        # we need mamba to resolve environment-tf
-        mamba-version: "*"
-        channel-priority: flexible
-        activate-environment: bio-core-tf-legacy
         environment-file: dev/environment-tf-legacy.yaml
-        python-version: ${{ matrix.python-version }}
+        channel-priority: flexible
+        extra-specs: |
+          python=${{ matrix.python-version }}
     - name: additional setup
       shell: bash -l {0}
       run: |
-        conda remove --force bioimageio.spec
+        mamba remove --force bioimageio.spec
         pip install --no-deps git+https://github.com/bioimage-io/spec-bioimage-io
         pip install --no-deps -e .
     - name: pytest-base-bioimage-spec-tf-legacy
@@ -131,14 +121,13 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: setup conda
-      uses: conda-incubator/setup-miniconda@v2
+    - name: Install Conda environment with Micromamba
+      uses: mamba-org/provision-with-micromamba@main
       with:
-        auto-update-conda: true
-        auto-activate-base: true
-        activate-environment: ""
+        channels: conda-forge
+        extra-specs: |
+          boa
     - name: linux conda build
       shell: bash -l {0}
       run: |
-        conda install -n base -c conda-forge conda-build pip -y
-        conda build -c conda-forge conda-recipe
+        conda mambabuild -c conda-forge conda-recipe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,6 +125,7 @@ jobs:
       uses: mamba-org/provision-with-micromamba@main
       with:
         environment-file: false
+        environment-name: build-env
         channels: conda-forge
         extra-specs: |
           boa

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
     - name: additional setup
       shell: bash -l {0}
       run: |
-        conda remove --force bioimageio.spec
+        conda remove --yes --force bioimageio.spec
         pip install --no-deps git+https://github.com/bioimage-io/spec-bioimage-io
         pip install --no-deps -e .
     - name: pytest-base-bioimage-spec-main
@@ -82,7 +82,7 @@ jobs:
     - name: additional setup
       shell: bash -l {0}
       run: |
-        conda remove --force bioimageio.spec
+        conda remove --yes --force bioimageio.spec
         pip install --no-deps git+https://github.com/bioimage-io/spec-bioimage-io
         pip install --no-deps -e .
     - name: pytest-base-bioimage-spec-tf
@@ -106,7 +106,7 @@ jobs:
     - name: additional setup
       shell: bash -l {0}
       run: |
-        conda remove --force bioimageio.spec
+        conda remove --yes --force bioimageio.spec
         pip install --no-deps git+https://github.com/bioimage-io/spec-bioimage-io
         pip install --no-deps -e .
     - name: pytest-base-bioimage-spec-tf-legacy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
     - name: additional setup
       shell: bash -l {0}
       run: |
-        mamba remove --force bioimageio.spec
+        conda remove --force bioimageio.spec
         pip install --no-deps git+https://github.com/bioimage-io/spec-bioimage-io
         pip install --no-deps -e .
     - name: pytest-base-bioimage-spec-main
@@ -82,7 +82,7 @@ jobs:
     - name: additional setup
       shell: bash -l {0}
       run: |
-        mamba remove --force bioimageio.spec
+        conda remove --force bioimageio.spec
         pip install --no-deps git+https://github.com/bioimage-io/spec-bioimage-io
         pip install --no-deps -e .
     - name: pytest-base-bioimage-spec-tf
@@ -106,7 +106,7 @@ jobs:
     - name: additional setup
       shell: bash -l {0}
       run: |
-        mamba remove --force bioimageio.spec
+        conda remove --force bioimageio.spec
         pip install --no-deps git+https://github.com/bioimage-io/spec-bioimage-io
         pip install --no-deps -e .
     - name: pytest-base-bioimage-spec-tf-legacy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,6 +124,7 @@ jobs:
     - name: Install Conda environment with Micromamba
       uses: mamba-org/provision-with-micromamba@main
       with:
+        environment-file: false
         channels: conda-forge
         extra-specs: |
           boa

--- a/dev/environment-base.yaml
+++ b/dev/environment-base.yaml
@@ -9,6 +9,7 @@ dependencies:
   - h5py >=2.10,<2.11
   - mypy
   - pip
+  - pre-commit
   - pytest
   - python >=3.7,<3.8  # this environment is only available for python 3.7
   - xarray


### PR DESCRIPTION
this PR updates the build workflow to use micromamba instead of miniconda with the mamba package.
For the build job [boa](https://boa-build.readthedocs.io/en/latest/getting_started.html#basic-usage)'s `conda mambabuild` command is used--a drop in replacement for `conda build`. In the future we might want to switch to the new build spec, which is currently still experimental, using the command `boa build`...

These updates should fix the current CI issues that first occurred in #322  