### PR TITLE
do not visit root_path

### DIFF
--- a/bioimageio/core/resource_io/utils.py
+++ b/bioimageio/core/resource_io/utils.py
@@ -43,6 +43,16 @@ class SourceNodeChecker(NodeVisitor):
     def visit_WindowsPath(self, leaf: pathlib.WindowsPath):
         self._visit_source(leaf)
 
+    def generic_visit(self, node):
+        """Called if no explicit visitor function exists for a node."""
+
+        if isinstance(node, raw_nodes.RawNode):
+            for field, value in iter_fields(node):
+                if field != "root_path":  # do not visit root_path, as it might be an incomplete (non-available) URL
+                    self.visit(value)
+        else:
+            super().generic_visit(node)
+
 
 class SourceNodeTransformer(NodeTransformer):
     """


### PR DESCRIPTION
when checking valid URL's `root_path` should not be expected to be a valid URL... 