### PR TITLE
Fix critical bug in predict with tiling

### DIFF
--- a/bioimageio/core/prediction.py
+++ b/bioimageio/core/prediction.py
@@ -330,13 +330,16 @@ def _parse_tiling(tiling, input_specs, output_specs):
         # override metadata defaults with provided dict
         if isinstance(tiling, dict):
             for key in ["halo", "tile", "scale"]:
-                default_tiling.update(tiling.get(key, dict()))
+                default_tiling[key].update(tiling.get(key, dict()))
         tiling = default_tiling
         check_tiling(tiling)
+
     elif isinstance(tiling, bool) and not tiling:
         raise NotImplementedError("Should be unreachable")
+
     else:
         raise ValueError(f"Invalid argument for tiling: {tiling}")
+
     return tiling
 
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     ],
     packages=find_namespace_packages(exclude=["tests"]),  # Required
     install_requires=[
-        "bioimageio.spec==0.4.9.*",
+        "bioimageio.spec==0.4.9",
         "imageio>=2.5",
         "numpy",
         "ruamel.yaml",

--- a/tests/test_bioimageio_spec_version.py
+++ b/tests/test_bioimageio_spec_version.py
@@ -26,11 +26,16 @@ def test_bioimageio_spec_version():
     # get currently pinned bioimageio.spec version
     meta = metadata("bioimageio.core")
     req = meta["Requires-Dist"]
-    assert req.startswith("bioimageio.spec (==")
-    pmaj, pmin, ppatch, *asterisk_and_rest = req[len("bioimageio.spec (==") :].split(".")
-    assert asterisk_and_rest[0].startswith(
-        "*"
-    ), "bioimageio.spec version should be pinned down to patch, e.g. '0.4.9.*'"
+    print(req)
+    assert req.startswith("bioimageio.spec ==")
+    spec_ver = req[len("bioimageio.spec ==") :]
+    assert spec_ver.count(".") == 2
+    pmaj, pmin, ppatchand_and_post = spec_ver.split(".")
+    assert (ppatchand_and_post.isdigit() or ppatchand_and_post[:-1].isdigit()) and (
+        ppatchand_and_post[-1] == "*" or ppatchand_and_post[-1].isdigit()
+    ), "bioimageio.spec version should be pinned down to patch, e.g. '0.4.9*'"
+
+    ppatch = ppatchand_and_post[:-1] if ppatchand_and_post[-1] == "*" else ppatchand_and_post
     pinned = Version(f"{pmaj}.{pmin}.{ppatch}")
 
     assert pinned >= released, "bioimageio.spec pinned to an old version!"

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -110,9 +110,7 @@ def _test_predict_with_padding(model, tmp_path):
     check_result()
 
     # test with fixed padding
-    predict_image(
-        model, in_path, out_path, padding={"x": original_shape[0], "y": original_shape[1], "mode": "fixed"}
-    )
+    predict_image(model, in_path, out_path, padding={"x": original_shape[0], "y": original_shape[1], "mode": "fixed"})
     check_result()
 
     # test with automated padding
@@ -135,7 +133,7 @@ def test_predict_image_with_padding_channel_last(stardist, tmp_path):
     _test_predict_with_padding(stardist, tmp_path)
 
 
-def _test_predict_image_with_tiling(model, tmp_path, exp_mean_deviation):
+def _test_predict_image_with_tiling(model, tmp_path: Path, exp_mean_deviation):
     from bioimageio.core.prediction import predict_image
 
     spec = load_resource_description(model)
@@ -168,27 +166,27 @@ def _test_predict_image_with_tiling(model, tmp_path, exp_mean_deviation):
 
 # prediction with tiling with the parameters above may not be suited for any model
 # so we only run it for the pytorch unet2d here
-def test_predict_image_with_tiling_1(unet2d_nuclei_broad_model, tmp_path):
+def test_predict_image_with_tiling_1(unet2d_nuclei_broad_model, tmp_path: Path):
     _test_predict_image_with_tiling(unet2d_nuclei_broad_model, tmp_path, 0.012)
 
 
-def test_predict_image_with_tiling_2(unet2d_diff_output_shape, tmp_path):
-    _test_predict_image_with_tiling(unet2d_diff_output_shape, tmp_path, 0.012)
+def test_predict_image_with_tiling_2(unet2d_diff_output_shape, tmp_path: Path):
+    _test_predict_image_with_tiling(unet2d_diff_output_shape, tmp_path, 0.06)
 
 
-def test_predict_image_with_tiling_3(shape_change_model, tmp_path):
+def test_predict_image_with_tiling_3(shape_change_model, tmp_path: Path):
     _test_predict_image_with_tiling(shape_change_model, tmp_path, 0.012)
 
 
-def test_predict_image_with_tiling_channel_last(stardist, tmp_path):
+def test_predict_image_with_tiling_channel_last(stardist, tmp_path: Path):
     _test_predict_image_with_tiling(stardist, tmp_path, 0.13)
 
 
-def test_predict_image_with_tiling_fixed_output_shape(unet2d_fixed_shape, tmp_path):
+def test_predict_image_with_tiling_fixed_output_shape(unet2d_fixed_shape, tmp_path: Path):
     _test_predict_image_with_tiling(unet2d_fixed_shape, tmp_path, 0.025)
 
 
-def test_predict_images(unet2d_nuclei_broad_model, tmp_path):
+def test_predict_images(unet2d_nuclei_broad_model, tmp_path: Path):
     from bioimageio.core.prediction import predict_images
 
     n_images = 5


### PR DESCRIPTION
This fixes a critical bug where the values passed for tiling are not taken into account and the code always uses the default tiling. This is very nasty, because the default tiling is usually quite small and leads to blocking artifacts.