### PR TITLE
Fix pytorch_state_dict import from library

### DIFF
--- a/bioimageio/core/digest_spec.py
+++ b/bioimageio/core/digest_spec.py
@@ -20,7 +20,7 @@ from typing import (
 from numpy.typing import NDArray
 from typing_extensions import Unpack, assert_never
 
-from bioimageio.spec._internal.io_utils import HashKwargs, download
+from bioimageio.spec._internal.io import HashKwargs, download
 from bioimageio.spec.common import FileSource
 from bioimageio.spec.model import AnyModelDescr, v0_4, v0_5
 from bioimageio.spec.model.v0_4 import CallableFromDepencency, CallableFromFile
@@ -51,7 +51,7 @@ def import_callable(node: type, /) -> Callable[..., Any]:
 
 
 @import_callable.register
-def _(node: CallableFromDepencency) -> Callable[..., Any]:
+def _(node: CallableFromDepencency, **kwargs: Unpack[HashKwargs]) -> Callable[..., Any]:
     module = importlib.import_module(node.module_name)
     c = getattr(module, str(node.callable_name))
     if not callable(c):
@@ -61,7 +61,9 @@ def _(node: CallableFromDepencency) -> Callable[..., Any]:
 
 
 @import_callable.register
-def _(node: ArchitectureFromLibraryDescr) -> Callable[..., Any]:
+def _(
+    node: ArchitectureFromLibraryDescr, **kwargs: Unpack[HashKwargs]
+) -> Callable[..., Any]:
     module = importlib.import_module(node.import_from)
     c = getattr(module, str(node.callable))
     if not callable(c):


### PR DESCRIPTION
## Issue

`PyTorchModelAdaptor` passes a `sha256` keyword to the callable responsible for instantiating the model:
https://github.com/bioimage-io/core-bioimage-io-python/blob/ff8af21f51907d27a4cc2f6103249d22d40947b7/bioimageio/core/model_adapters/_pytorch_model_adapter.py#L107

If the callable is an `ArchitectureFromLibraryDescr`, then an error will be raised since there is no `kwargs` in the function signature:
https://github.com/bioimage-io/core-bioimage-io-python/blob/ff8af21f51907d27a4cc2f6103249d22d40947b7/bioimageio/core/digest_spec.py#L64

## Fix

Add `kwargs` to the function signature (and that of other callables).
https://github.com/bioimage-io/core-bioimage-io-python/blob/7681ab7a6c10774e200a8d4b6ebf75dbc3a36453/bioimageio/core/digest_spec.py#L65

## SIde note

The pre-commit hooks forced me to fix an import, is it due to me not having the right version of the specs?
https://github.com/bioimage-io/core-bioimage-io-python/blob/7681ab7a6c10774e200a8d4b6ebf75dbc3a36453/bioimageio/core/digest_spec.py#L23