### PR TITLE
Separates pipeline build logic per version

### DIFF
--- a/bioimageio/core/proc_ops.py
+++ b/bioimageio/core/proc_ops.py
@@ -3,7 +3,6 @@ from abc import ABC, abstractmethod
 from dataclasses import InitVar, dataclass, field
 from typing import (
     Collection,
-    List,
     Literal,
     Mapping,
     Optional,
@@ -19,6 +18,9 @@ from typing_extensions import Self, assert_never
 
 from bioimageio.spec.model import v0_4, v0_5
 from bioimageio.spec.model.v0_5 import TensorId
+from bioimageio.spec.model.v0_5 import (
+    _convert_proc,  # pyright: ignore [reportPrivateUsage]
+)
 
 from ._op_base import BlockedOperator, Operator
 from .axis import AxisId, PerAxis
@@ -691,8 +693,11 @@ def get_proc_class(proc_spec: ProcDescr):
     else:
         assert_never(proc_spec)
 
-def preproc_v4_to_processing(inp: v0_4.InputTensorDescr, proc_spec: v0_4.PreprocessingDescr,) -> Processing:
-    from bioimageio.spec.model.v0_5 import _convert_proc # pyright: ignore [reportPrivateUsage]
+
+def preproc_v4_to_processing(
+    inp: v0_4.InputTensorDescr,
+    proc_spec: v0_4.PreprocessingDescr,
+) -> Processing:
     member_id = TensorId(str(inp.name))
     if isinstance(proc_spec, v0_4.BinarizeDescr):
         return Binarize.from_proc_descr(proc_spec, member_id)
@@ -708,15 +713,20 @@ def preproc_v4_to_processing(inp: v0_4.InputTensorDescr, proc_spec: v0_4.Preproc
         if proc_spec.kwargs.mode == "fixed":
             axes = inp.axes
             v5_proc_spec = _convert_proc(proc_spec, axes)
-            assert isinstance(v5_proc_spec, v0_5.FixedZeroMeanUnitVarianceDescr) #FIXME
+            assert isinstance(
+                v5_proc_spec, v0_5.FixedZeroMeanUnitVarianceDescr
+            )  # FIXME
             return FixedZeroMeanUnitVariance.from_proc_descr(v5_proc_spec, member_id)
         else:
             return ZeroMeanUnitVariance.from_proc_descr(proc_spec, member_id)
     else:
         assert_never(proc_spec)
 
-def postproc_v4_to_processing(inp: v0_4.OutputTensorDescr, proc_spec: v0_4.PostprocessingDescr,) -> Processing:
-    from bioimageio.spec.model.v0_5 import _convert_proc # pyright: ignore [reportPrivateUsage]
+
+def postproc_v4_to_processing(
+    inp: v0_4.OutputTensorDescr,
+    proc_spec: v0_4.PostprocessingDescr,
+) -> Processing:
     member_id = TensorId(str(inp.name))
     if isinstance(proc_spec, v0_4.BinarizeDescr):
         return Binarize.from_proc_descr(proc_spec, member_id)
@@ -734,14 +744,20 @@ def postproc_v4_to_processing(inp: v0_4.OutputTensorDescr, proc_spec: v0_4.Postp
         if proc_spec.kwargs.mode == "fixed":
             axes = inp.axes
             v5_proc_spec = _convert_proc(proc_spec, axes)
-            assert isinstance(v5_proc_spec, v0_5.FixedZeroMeanUnitVarianceDescr) #FIXME
+            assert isinstance(
+                v5_proc_spec, v0_5.FixedZeroMeanUnitVarianceDescr
+            )  # FIXME
             return FixedZeroMeanUnitVariance.from_proc_descr(v5_proc_spec, member_id)
         else:
             return ZeroMeanUnitVariance.from_proc_descr(proc_spec, member_id)
     else:
         assert_never(proc_spec)
 
-def preproc_v5_to_processing(inp: v0_5.InputTensorDescr, proc_spec: v0_5.PreprocessingDescr,) -> Processing:
+
+def preproc_v5_to_processing(
+    inp: v0_5.InputTensorDescr,
+    proc_spec: v0_5.PreprocessingDescr,
+) -> Processing:
     if isinstance(proc_spec, v0_5.BinarizeDescr):
         return Binarize.from_proc_descr(proc_spec, inp.id)
     elif isinstance(proc_spec, v0_5.ClipDescr):
@@ -761,7 +777,11 @@ def preproc_v5_to_processing(inp: v0_5.InputTensorDescr, proc_spec: v0_5.Preproc
     else:
         assert_never(proc_spec)
 
-def postproc_v5_to_processing(inp: v0_5.OutputTensorDescr, proc_spec: v0_5.PostprocessingDescr,) -> Processing:
+
+def postproc_v5_to_processing(
+    inp: v0_5.OutputTensorDescr,
+    proc_spec: v0_5.PostprocessingDescr,
+) -> Processing:
     if isinstance(proc_spec, v0_5.BinarizeDescr):
         return Binarize.from_proc_descr(proc_spec, inp.id)
     if isinstance(proc_spec, v0_5.ScaleMeanVarianceDescr):

--- a/bioimageio/core/proc_ops.py
+++ b/bioimageio/core/proc_ops.py
@@ -660,72 +660,9 @@ Processing = Union[
     ZeroMeanUnitVariance,
 ]
 
-
-def get_proc_class(proc_spec: ProcDescr):
-    if isinstance(proc_spec, (v0_4.BinarizeDescr, v0_5.BinarizeDescr)):
-        return Binarize
-    elif isinstance(proc_spec, (v0_4.ClipDescr, v0_5.ClipDescr)):
-        return Clip
-    elif isinstance(proc_spec, v0_5.EnsureDtypeDescr):
-        return EnsureDtype
-    elif isinstance(proc_spec, v0_5.FixedZeroMeanUnitVarianceDescr):
-        return FixedZeroMeanUnitVariance
-    elif isinstance(proc_spec, (v0_4.ScaleLinearDescr, v0_5.ScaleLinearDescr)):
-        return ScaleLinear
-    elif isinstance(
-        proc_spec, (v0_4.ScaleMeanVarianceDescr, v0_5.ScaleMeanVarianceDescr)
-    ):
-        return ScaleMeanVariance
-    elif isinstance(proc_spec, (v0_4.ScaleRangeDescr, v0_5.ScaleRangeDescr)):
-        return ScaleRange
-    elif isinstance(proc_spec, (v0_4.SigmoidDescr, v0_5.SigmoidDescr)):
-        return Sigmoid
-    elif (
-        isinstance(proc_spec, v0_4.ZeroMeanUnitVarianceDescr)
-        and proc_spec.kwargs.mode == "fixed"
-    ):
-        return FixedZeroMeanUnitVariance
-    elif isinstance(
-        proc_spec,
-        (v0_4.ZeroMeanUnitVarianceDescr, v0_5.ZeroMeanUnitVarianceDescr),
-    ):
-        return ZeroMeanUnitVariance
-    else:
-        assert_never(proc_spec)
-
-
-def preproc_v4_to_processing(
-    inp: v0_4.InputTensorDescr,
-    proc_spec: v0_4.PreprocessingDescr,
-) -> Processing:
-    member_id = TensorId(str(inp.name))
-    if isinstance(proc_spec, v0_4.BinarizeDescr):
-        return Binarize.from_proc_descr(proc_spec, member_id)
-    elif isinstance(proc_spec, v0_4.ClipDescr):
-        return Clip.from_proc_descr(proc_spec, member_id)
-    elif isinstance(proc_spec, v0_4.ScaleLinearDescr):
-        return ScaleLinear.from_proc_descr(proc_spec, member_id)
-    elif isinstance(proc_spec, v0_4.ScaleRangeDescr):
-        return ScaleRange.from_proc_descr(proc_spec, member_id)
-    elif isinstance(proc_spec, v0_4.SigmoidDescr):
-        return Sigmoid.from_proc_descr(proc_spec, member_id)
-    elif isinstance(proc_spec, v0_4.ZeroMeanUnitVarianceDescr):
-        if proc_spec.kwargs.mode == "fixed":
-            axes = inp.axes
-            v5_proc_spec = _convert_proc(proc_spec, axes)
-            assert isinstance(
-                v5_proc_spec, v0_5.FixedZeroMeanUnitVarianceDescr
-            )  # FIXME
-            return FixedZeroMeanUnitVariance.from_proc_descr(v5_proc_spec, member_id)
-        else:
-            return ZeroMeanUnitVariance.from_proc_descr(proc_spec, member_id)
-    else:
-        assert_never(proc_spec)
-
-
-def postproc_v4_to_processing(
-    inp: v0_4.OutputTensorDescr,
-    proc_spec: v0_4.PostprocessingDescr,
+def proc_descr_v4_to_op(
+    inp: Union[v0_4.InputTensorDescr, v0_4.OutputTensorDescr],
+    proc_spec: Union[v0_4.PreprocessingDescr, v0_4.PostprocessingDescr],
 ) -> Processing:
     member_id = TensorId(str(inp.name))
     if isinstance(proc_spec, v0_4.BinarizeDescr):
@@ -754,33 +691,9 @@ def postproc_v4_to_processing(
         assert_never(proc_spec)
 
 
-def preproc_v5_to_processing(
-    inp: v0_5.InputTensorDescr,
-    proc_spec: v0_5.PreprocessingDescr,
-) -> Processing:
-    if isinstance(proc_spec, v0_5.BinarizeDescr):
-        return Binarize.from_proc_descr(proc_spec, inp.id)
-    elif isinstance(proc_spec, v0_5.ClipDescr):
-        return Clip.from_proc_descr(proc_spec, inp.id)
-    elif isinstance(proc_spec, v0_5.ScaleLinearDescr):
-        return ScaleLinear.from_proc_descr(proc_spec, inp.id)
-    elif isinstance(proc_spec, v0_5.ScaleRangeDescr):
-        return ScaleRange.from_proc_descr(proc_spec, inp.id)
-    elif isinstance(proc_spec, v0_5.SigmoidDescr):
-        return Sigmoid.from_proc_descr(proc_spec, inp.id)
-    elif isinstance(proc_spec, v0_5.EnsureDtypeDescr):
-        return EnsureDtype.from_proc_descr(proc_spec, inp.id)
-    elif isinstance(proc_spec, v0_5.ZeroMeanUnitVarianceDescr):
-        return ZeroMeanUnitVariance.from_proc_descr(proc_spec, inp.id)
-    elif isinstance(proc_spec, v0_5.FixedZeroMeanUnitVarianceDescr):
-        return FixedZeroMeanUnitVariance.from_proc_descr(proc_spec, inp.id)
-    else:
-        assert_never(proc_spec)
-
-
-def postproc_v5_to_processing(
-    inp: v0_5.OutputTensorDescr,
-    proc_spec: v0_5.PostprocessingDescr,
+def proc_descr_v5_to_op(
+    inp: Union[v0_5.InputTensorDescr, v0_5.OutputTensorDescr],
+    proc_spec: Union[v0_5.PreprocessingDescr, v0_5.PostprocessingDescr],
 ) -> Processing:
     if isinstance(proc_spec, v0_5.BinarizeDescr):
         return Binarize.from_proc_descr(proc_spec, inp.id)

--- a/bioimageio/core/proc_ops.py
+++ b/bioimageio/core/proc_ops.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 from dataclasses import InitVar, dataclass, field
 from typing import (
     Collection,
+    List,
     Literal,
     Mapping,
     Optional,
@@ -17,6 +18,7 @@ import xarray as xr
 from typing_extensions import Self, assert_never
 
 from bioimageio.spec.model import v0_4, v0_5
+from bioimageio.spec.model.v0_5 import TensorId
 
 from ._op_base import BlockedOperator, Operator
 from .axis import AxisId, PerAxis
@@ -686,5 +688,97 @@ def get_proc_class(proc_spec: ProcDescr):
         (v0_4.ZeroMeanUnitVarianceDescr, v0_5.ZeroMeanUnitVarianceDescr),
     ):
         return ZeroMeanUnitVariance
+    else:
+        assert_never(proc_spec)
+
+def preproc_v4_to_processing(inp: v0_4.InputTensorDescr, proc_spec: v0_4.PreprocessingDescr,) -> Processing:
+    from bioimageio.spec.model.v0_5 import _convert_proc # pyright: ignore [reportPrivateUsage]
+    member_id = TensorId(str(inp.name))
+    if isinstance(proc_spec, v0_4.BinarizeDescr):
+        return Binarize.from_proc_descr(proc_spec, member_id)
+    elif isinstance(proc_spec, v0_4.ClipDescr):
+        return Clip.from_proc_descr(proc_spec, member_id)
+    elif isinstance(proc_spec, v0_4.ScaleLinearDescr):
+        return ScaleLinear.from_proc_descr(proc_spec, member_id)
+    elif isinstance(proc_spec, v0_4.ScaleRangeDescr):
+        return ScaleRange.from_proc_descr(proc_spec, member_id)
+    elif isinstance(proc_spec, v0_4.SigmoidDescr):
+        return Sigmoid.from_proc_descr(proc_spec, member_id)
+    elif isinstance(proc_spec, v0_4.ZeroMeanUnitVarianceDescr):
+        if proc_spec.kwargs.mode == "fixed":
+            axes = inp.axes
+            v5_proc_spec = _convert_proc(proc_spec, axes)
+            assert isinstance(v5_proc_spec, v0_5.FixedZeroMeanUnitVarianceDescr) #FIXME
+            return FixedZeroMeanUnitVariance.from_proc_descr(v5_proc_spec, member_id)
+        else:
+            return ZeroMeanUnitVariance.from_proc_descr(proc_spec, member_id)
+    else:
+        assert_never(proc_spec)
+
+def postproc_v4_to_processing(inp: v0_4.OutputTensorDescr, proc_spec: v0_4.PostprocessingDescr,) -> Processing:
+    from bioimageio.spec.model.v0_5 import _convert_proc # pyright: ignore [reportPrivateUsage]
+    member_id = TensorId(str(inp.name))
+    if isinstance(proc_spec, v0_4.BinarizeDescr):
+        return Binarize.from_proc_descr(proc_spec, member_id)
+    if isinstance(proc_spec, v0_4.ScaleMeanVarianceDescr):
+        return ScaleMeanVariance.from_proc_descr(proc_spec, member_id)
+    elif isinstance(proc_spec, v0_4.ClipDescr):
+        return Clip.from_proc_descr(proc_spec, member_id)
+    elif isinstance(proc_spec, v0_4.ScaleLinearDescr):
+        return ScaleLinear.from_proc_descr(proc_spec, member_id)
+    elif isinstance(proc_spec, v0_4.ScaleRangeDescr):
+        return ScaleRange.from_proc_descr(proc_spec, member_id)
+    elif isinstance(proc_spec, v0_4.SigmoidDescr):
+        return Sigmoid.from_proc_descr(proc_spec, member_id)
+    elif isinstance(proc_spec, v0_4.ZeroMeanUnitVarianceDescr):
+        if proc_spec.kwargs.mode == "fixed":
+            axes = inp.axes
+            v5_proc_spec = _convert_proc(proc_spec, axes)
+            assert isinstance(v5_proc_spec, v0_5.FixedZeroMeanUnitVarianceDescr) #FIXME
+            return FixedZeroMeanUnitVariance.from_proc_descr(v5_proc_spec, member_id)
+        else:
+            return ZeroMeanUnitVariance.from_proc_descr(proc_spec, member_id)
+    else:
+        assert_never(proc_spec)
+
+def preproc_v5_to_processing(inp: v0_5.InputTensorDescr, proc_spec: v0_5.PreprocessingDescr,) -> Processing:
+    if isinstance(proc_spec, v0_5.BinarizeDescr):
+        return Binarize.from_proc_descr(proc_spec, inp.id)
+    elif isinstance(proc_spec, v0_5.ClipDescr):
+        return Clip.from_proc_descr(proc_spec, inp.id)
+    elif isinstance(proc_spec, v0_5.ScaleLinearDescr):
+        return ScaleLinear.from_proc_descr(proc_spec, inp.id)
+    elif isinstance(proc_spec, v0_5.ScaleRangeDescr):
+        return ScaleRange.from_proc_descr(proc_spec, inp.id)
+    elif isinstance(proc_spec, v0_5.SigmoidDescr):
+        return Sigmoid.from_proc_descr(proc_spec, inp.id)
+    elif isinstance(proc_spec, v0_5.EnsureDtypeDescr):
+        return EnsureDtype.from_proc_descr(proc_spec, inp.id)
+    elif isinstance(proc_spec, v0_5.ZeroMeanUnitVarianceDescr):
+        return ZeroMeanUnitVariance.from_proc_descr(proc_spec, inp.id)
+    elif isinstance(proc_spec, v0_5.FixedZeroMeanUnitVarianceDescr):
+        return FixedZeroMeanUnitVariance.from_proc_descr(proc_spec, inp.id)
+    else:
+        assert_never(proc_spec)
+
+def postproc_v5_to_processing(inp: v0_5.OutputTensorDescr, proc_spec: v0_5.PostprocessingDescr,) -> Processing:
+    if isinstance(proc_spec, v0_5.BinarizeDescr):
+        return Binarize.from_proc_descr(proc_spec, inp.id)
+    if isinstance(proc_spec, v0_5.ScaleMeanVarianceDescr):
+        return ScaleMeanVariance.from_proc_descr(proc_spec, inp.id)
+    elif isinstance(proc_spec, v0_5.ClipDescr):
+        return Clip.from_proc_descr(proc_spec, inp.id)
+    elif isinstance(proc_spec, v0_5.ScaleLinearDescr):
+        return ScaleLinear.from_proc_descr(proc_spec, inp.id)
+    elif isinstance(proc_spec, v0_5.ScaleRangeDescr):
+        return ScaleRange.from_proc_descr(proc_spec, inp.id)
+    elif isinstance(proc_spec, v0_5.SigmoidDescr):
+        return Sigmoid.from_proc_descr(proc_spec, inp.id)
+    elif isinstance(proc_spec, v0_5.EnsureDtypeDescr):
+        return EnsureDtype.from_proc_descr(proc_spec, inp.id)
+    elif isinstance(proc_spec, v0_5.ZeroMeanUnitVarianceDescr):
+        return ZeroMeanUnitVariance.from_proc_descr(proc_spec, inp.id)
+    elif isinstance(proc_spec, v0_5.FixedZeroMeanUnitVarianceDescr):
+        return FixedZeroMeanUnitVariance.from_proc_descr(proc_spec, inp.id)
     else:
         assert_never(proc_spec)

--- a/bioimageio/core/proc_setup.py
+++ b/bioimageio/core/proc_setup.py
@@ -19,10 +19,8 @@ from .proc_ops import (
     EnsureDtype,
     Processing,
     UpdateStats,
-    postproc_v4_to_processing,
-    postproc_v5_to_processing,
-    preproc_v4_to_processing,
-    preproc_v5_to_processing,
+    proc_descr_v4_to_op,
+    proc_descr_v5_to_op,
 )
 from .sample import Sample
 from .stat_calculators import StatsCalculator
@@ -149,7 +147,7 @@ def _prepare_v4_preprocs(
             EnsureDtype(input=member_id, output=member_id, dtype=t_descr.data_type)
         )
         for proc_d in t_descr.preprocessing:
-            procs.append(preproc_v4_to_processing(t_descr, proc_d))
+            procs.append(proc_descr_v4_to_op(t_descr, proc_d))
     return procs
 
 
@@ -163,7 +161,7 @@ def _prepare_v4_postprocs(
             EnsureDtype(input=member_id, output=member_id, dtype=t_descr.data_type)
         )
         for proc_d in t_descr.postprocessing:
-            procs.append(postproc_v4_to_processing(t_descr, proc_d))
+            procs.append(proc_descr_v4_to_op(t_descr, proc_d))
     return procs
 
 
@@ -173,7 +171,7 @@ def _prepare_v5_preprocs(
     procs: List[Processing] = []
     for t_descr in tensor_descrs:
         for proc_d in t_descr.preprocessing:
-            procs.append(preproc_v5_to_processing(t_descr, proc_d))
+            procs.append(proc_descr_v5_to_op(t_descr, proc_d))
     return procs
 
 
@@ -183,7 +181,7 @@ def _prepare_v5_postprocs(
     procs: List[Processing] = []
     for t_descr in tensor_descrs:
         for proc_d in t_descr.postprocessing:
-            procs.append(postproc_v5_to_processing(t_descr, proc_d))
+            procs.append(proc_descr_v5_to_op(t_descr, proc_d))
     return procs
 
 

--- a/bioimageio/core/proc_setup.py
+++ b/bioimageio/core/proc_setup.py
@@ -143,11 +143,11 @@ def _prepare_v4_preprocs(
     procs: List[Processing] = []
     for t_descr in tensor_descrs:
         member_id = TensorId(str(t_descr.name))
-        procs.append(
-            EnsureDtype(input=member_id, output=member_id, dtype=t_descr.data_type)
-        )
+        ensure_dtype = EnsureDtype(input=member_id, output=member_id, dtype=t_descr.data_type)
+        procs.append(ensure_dtype)
         for proc_d in t_descr.preprocessing:
             procs.append(proc_descr_v4_to_op(t_descr, proc_d))
+        procs.append(ensure_dtype)
     return procs
 
 
@@ -157,11 +157,11 @@ def _prepare_v4_postprocs(
     procs: List[Processing] = []
     for t_descr in tensor_descrs:
         member_id = TensorId(str(t_descr.name))
-        procs.append(
-            EnsureDtype(input=member_id, output=member_id, dtype=t_descr.data_type)
-        )
+        ensure_dtype = EnsureDtype(input=member_id, output=member_id, dtype=t_descr.data_type)
+        procs.append(ensure_dtype)
         for proc_d in t_descr.postprocessing:
             procs.append(proc_descr_v4_to_op(t_descr, proc_d))
+        procs.append(ensure_dtype)
     return procs
 
 

--- a/bioimageio/core/proc_setup.py
+++ b/bioimageio/core/proc_setup.py
@@ -6,7 +6,6 @@ from typing import (
     Optional,
     Sequence,
     Set,
-    Tuple,
     Union,
 )
 
@@ -15,13 +14,11 @@ from typing_extensions import assert_never
 from bioimageio.spec.model import AnyModelDescr, v0_4, v0_5
 from bioimageio.spec.model.v0_5 import TensorId
 
-from .digest_spec import get_member_ids
 from .proc_ops import (
     AddKnownDatasetStats,
     EnsureDtype,
     Processing,
     UpdateStats,
-    get_proc_class,
     postproc_v4_to_processing,
     postproc_v5_to_processing,
     preproc_v4_to_processing,
@@ -141,7 +138,10 @@ def get_requried_sample_measures(model: AnyModelDescr) -> RequiredSampleMeasures
         {m for m in s.post_measures if isinstance(m, SampleMeasureBase)},
     )
 
-def _prepare_v4_preprocs(tensor_descrs: Sequence[v0_4.InputTensorDescr]) -> List[Processing]:
+
+def _prepare_v4_preprocs(
+    tensor_descrs: Sequence[v0_4.InputTensorDescr],
+) -> List[Processing]:
     procs: List[Processing] = []
     for t_descr in tensor_descrs:
         member_id = TensorId(str(t_descr.name))
@@ -152,7 +152,10 @@ def _prepare_v4_preprocs(tensor_descrs: Sequence[v0_4.InputTensorDescr]) -> List
             procs.append(preproc_v4_to_processing(t_descr, proc_d))
     return procs
 
-def _prepare_v4_postprocs(tensor_descrs: Sequence[v0_4.OutputTensorDescr]) -> List[Processing]:
+
+def _prepare_v4_postprocs(
+    tensor_descrs: Sequence[v0_4.OutputTensorDescr],
+) -> List[Processing]:
     procs: List[Processing] = []
     for t_descr in tensor_descrs:
         member_id = TensorId(str(t_descr.name))
@@ -163,14 +166,20 @@ def _prepare_v4_postprocs(tensor_descrs: Sequence[v0_4.OutputTensorDescr]) -> Li
             procs.append(postproc_v4_to_processing(t_descr, proc_d))
     return procs
 
-def _prepare_v5_preprocs(tensor_descrs: Sequence[v0_5.InputTensorDescr]) -> List[Processing]:
+
+def _prepare_v5_preprocs(
+    tensor_descrs: Sequence[v0_5.InputTensorDescr],
+) -> List[Processing]:
     procs: List[Processing] = []
     for t_descr in tensor_descrs:
         for proc_d in t_descr.preprocessing:
             procs.append(preproc_v5_to_processing(t_descr, proc_d))
     return procs
 
-def _prepare_v5_postprocs(tensor_descrs: Sequence[v0_5.OutputTensorDescr]) -> List[Processing]:
+
+def _prepare_v5_postprocs(
+    tensor_descrs: Sequence[v0_5.OutputTensorDescr],
+) -> List[Processing]:
     procs: List[Processing] = []
     for t_descr in tensor_descrs:
         for proc_d in t_descr.postprocessing:


### PR DESCRIPTION
[This issue](https://github.com/bioimage-io/use-cases/issues/8) was due to `FixedZeroMeanUnitVariance` not being able to be created from a v4 preprocessing descriptor.

This PR splits the logic for v4 and v5 pipeline creation, making the types more visible and fixing the issue.