### PR TITLE
fix(deps): set xarray uppper bound

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ _ = setup(
         "ruyaml",
         "tqdm",
         "typing-extensions",
-        "xarray",
+        "xarray<2025.3.0",
     ],
     include_package_data=True,
     extras_require={


### PR DESCRIPTION
The new xarray release is incompatible with `bioimage-core` because the package structure has been moved around and now some imports break.

This PR sets the upper bound to use the last working release.

Resolves #454 

After this is merged could we get a patch release 0.7.1 of bioimage core so we can update the dependency in CAREamics? 

Thanks