### PR TITLE
Improve error message when torch.load(weights_only=True) fails on non-pure state dicts

### DIFF
--- a/src/bioimageio/core/backends/pytorch_backend.py
+++ b/src/bioimageio/core/backends/pytorch_backend.py
@@ -154,7 +154,23 @@ def load_torch_state_dict(
         if Version(str(torch.__version__)) < Version("1.13"):
             state = torch.load(f, map_location=devices[0])
         else:
-            state = torch.load(f, map_location=devices[0], weights_only=True)
+            try:
+                state = torch.load(f, map_location=devices[0], weights_only=True)
+            except Exception as e:
+                raise ValueError(
+                    f"Failed to load weights with `weights_only=True`: {e}\n\n"
+                    "This usually means the weights file contains non-tensor objects "
+                    "(e.g. numpy arrays, custom classes, or nested dicts with metadata). "
+                    "The BioImage.IO spec requires a pure state dict — an OrderedDict "
+                    "mapping parameter names to tensors only.\n\n"
+                    "To fix this, extract only the state dict from your checkpoint:\n\n"
+                    "    import torch\n"
+                    "    checkpoint = torch.load('original.pth', weights_only=False)\n"
+                    "    # Inspect the checkpoint to find the state dict key, e.g.:\n"
+                    "    #   checkpoint.keys()  -> dict_keys(['model', 'optimizer', ...])\n"
+                    "    torch.save(checkpoint['model'], 'weights.pt')\n\n"
+                    "Then reference 'weights.pt' in your bioimageio.yaml."
+                ) from e
 
     incompatible = model.load_state_dict(state)
     if (

--- a/src/bioimageio/core/backends/pytorch_backend.py
+++ b/src/bioimageio/core/backends/pytorch_backend.py
@@ -157,20 +157,21 @@ def load_torch_state_dict(
             try:
                 state = torch.load(f, map_location=devices[0], weights_only=True)
             except Exception as e:
-                raise ValueError(
+                msg = (
                     f"Failed to load weights with `weights_only=True`: {e}\n\n"
-                    "This usually means the weights file contains non-tensor objects "
-                    "(e.g. numpy arrays, custom classes, or nested dicts with metadata). "
-                    "The BioImage.IO spec requires a pure state dict — an OrderedDict "
-                    "mapping parameter names to tensors only.\n\n"
-                    "To fix this, extract only the state dict from your checkpoint:\n\n"
-                    "    import torch\n"
-                    "    checkpoint = torch.load('original.pth', weights_only=False)\n"
-                    "    # Inspect the checkpoint to find the state dict key, e.g.:\n"
-                    "    #   checkpoint.keys()  -> dict_keys(['model', 'optimizer', ...])\n"
-                    "    torch.save(checkpoint['model'], 'weights.pt')\n\n"
-                    "Then reference 'weights.pt' in your bioimageio.yaml."
-                ) from e
+                    + "This usually means the weights file contains non-tensor objects"
+                    + " (e.g. numpy arrays, custom classes, or nested dicts with"
+                    + " metadata). The BioImage.IO spec requires a pure state dict —"
+                    + " an OrderedDict mapping parameter names to tensors only.\n\n"
+                    + "To fix this, extract only the state dict from your checkpoint:\n\n"
+                    + "    import torch\n"
+                    + "    checkpoint = torch.load('original.pth', weights_only=False)\n"
+                    + "    # Inspect keys, e.g.: checkpoint.keys()"
+                    + " -> dict_keys(['model', 'optimizer', ...])\n"
+                    + "    torch.save(checkpoint['model'], 'weights.pt')\n\n"
+                    + "Then reference 'weights.pt' in your bioimageio.yaml."
+                )
+                raise ValueError(msg) from e
 
     incompatible = model.load_state_dict(state)
     if (


### PR DESCRIPTION
## Problem

When loading `pytorch_state_dict` weights, `bioimageio.core` calls
`torch.load(f, weights_only=True)`. If the `.pth` file contains anything
beyond plain tensors — numpy arrays, custom Python classes, nested dicts
with metadata (common with frameworks like deepflash2, fastai, etc.) —
PyTorch raises a `WeightsUnpickler` error that is opaque and provides no
guidance on how to fix the packaging problem.

A contributor who hit this when submitting their model had to do
significant trial-and-error to discover the root cause.

Reproducer:
```python
# deepflash2 saves: {'model': <state_dict>, 'stats': np.array([...])}
data = torch.load('original.pth', weights_only=False)
# torch.load(..., weights_only=True) → cryptic WeightsUnpickler error
```

Closes #484, reported by @oeway during a model submission run.

## Fix

Wrap the `torch.load(..., weights_only=True)` call in a `try/except` and
re-raise a `ValueError` with:
- The original exception message
- An explanation of the pure-state-dict requirement
- The exact extraction snippet the contributor needs to fix their weights file

## Testing

Existing tests continue to pass. The error path is triggered only when
`weights_only=True` loading fails, which is not covered by current tests
(the fix improves the error message, not the loading logic itself).

cc @fynnbe