### PR TITLE
Add spec→runtime integration test for softmax postprocessing

### DIFF
--- a/tests/test_proc_ops.py
+++ b/tests/test_proc_ops.py
@@ -458,3 +458,72 @@ def test_softmax_with_scipy(tid: MemberId):
         dims=axes,
     )
     xr.testing.assert_allclose(exp, sample.members[tid].data, rtol=1e-5, atol=1e-7)
+
+
+def test_softmax_from_spec_descr(tid: MemberId, tmp_path: "Path"):
+    """Verify the full spec→runtime path for softmax postprocessing.
+
+    SoftmaxDescr (bioimageio.spec v0.5.9+) must be:
+      1. Accepted as a valid postprocessing descriptor by the spec.
+      2. Correctly dispatched by get_proc() to the Softmax operator.
+      3. Numerically identical to scipy.special.softmax over the channel axis.
+
+    This test guards against regressions where softmax is defined in the spec
+    but silently dropped or misrouted in the core runtime. It also documents
+    that softmax postprocessing IS supported end-to-end without needing to
+    embed it inside the model's forward() method.
+    """
+    from pathlib import Path
+
+    from bioimageio.core.proc_ops import Softmax, get_proc
+    from bioimageio.spec.model import v0_5
+
+    shape = (3, 16, 16)
+    axes = ("channel", "y", "x")
+    np_data = np.random.rand(*shape).astype(np.float32)
+    data = xr.DataArray(np_data, dims=axes)
+    sample = Sample(members={tid: Tensor.from_xarray(data)}, stat={}, id=None)
+
+    # Write a dummy test tensor so FileDescr validates
+    test_npy = tmp_path / "test.npy"
+    np.save(test_npy, np_data)
+
+    # Build spec descriptor — SoftmaxDescr requires bioimageio.spec >= 0.5.9
+    softmax_descr = v0_5.SoftmaxDescr(
+        kwargs=v0_5.SoftmaxKwargs(axis=AxisId("channel"))
+    )
+    tensor_descr = v0_5.OutputTensorDescr(
+        id=v0_5.TensorId(str(tid)),
+        axes=[
+            v0_5.ChannelAxis(
+                channel_names=[
+                    v0_5.Identifier("c0"),
+                    v0_5.Identifier("c1"),
+                    v0_5.Identifier("c2"),
+                ]
+            ),
+            v0_5.SpaceOutputAxis(id=AxisId("y"), size=16),
+            v0_5.SpaceOutputAxis(id=AxisId("x"), size=16),
+        ],
+        test_tensor=v0_5.FileDescr(source=test_npy),
+        postprocessing=[softmax_descr],
+    )
+
+    # Dispatch through get_proc — must return a Softmax instance
+    op = get_proc(softmax_descr, tensor_descr)
+    assert isinstance(op, Softmax), f"Expected Softmax, got {type(op)}"
+
+    # Apply and verify numerical correctness
+    op(sample)
+    expected = scipy.special.softmax(np_data, axis=0)
+    xr.testing.assert_allclose(
+        xr.DataArray(expected, dims=axes),
+        sample.members[tid].data,
+        rtol=1e-5,
+        atol=1e-7,
+    )
+
+    # Output must be a valid probability distribution (sums to 1 over channel axis)
+    result = np.array(sample.members[tid].data)
+    channel_sums = result.sum(axis=0)
+    np.testing.assert_allclose(channel_sums, np.ones_like(channel_sums), atol=1e-6)

--- a/tests/test_proc_ops.py
+++ b/tests/test_proc_ops.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Iterable, Optional, Tuple, Type, TypeVar
 
 import numpy as np
@@ -460,7 +461,7 @@ def test_softmax_with_scipy(tid: MemberId):
     xr.testing.assert_allclose(exp, sample.members[tid].data, rtol=1e-5, atol=1e-7)
 
 
-def test_softmax_from_spec_descr(tid: MemberId, tmp_path: "Path"):
+def test_softmax_from_spec_descr(tid: MemberId, tmp_path: Path):
     """Verify the full spec→runtime path for softmax postprocessing.
 
     SoftmaxDescr (bioimageio.spec v0.5.9+) must be:
@@ -473,8 +474,6 @@ def test_softmax_from_spec_descr(tid: MemberId, tmp_path: "Path"):
     that softmax postprocessing IS supported end-to-end without needing to
     embed it inside the model's forward() method.
     """
-    from pathlib import Path
-
     from bioimageio.core.proc_ops import Softmax, get_proc
     from bioimageio.spec.model import v0_5
 
@@ -524,6 +523,9 @@ def test_softmax_from_spec_descr(tid: MemberId, tmp_path: "Path"):
     )
 
     # Output must be a valid probability distribution (sums to 1 over channel axis)
-    result = np.array(sample.members[tid].data)
-    channel_sums = result.sum(axis=0)
-    np.testing.assert_allclose(channel_sums, np.ones_like(channel_sums), atol=1e-6)
+    out_data = sample.members[tid].data
+    assert out_data is not None
+    channel_sums = out_data.sum(dim="channel")
+    xr.testing.assert_allclose(
+        channel_sums, xr.ones_like(channel_sums), atol=1e-6, rtol=0
+    )


### PR DESCRIPTION
## Problem

The existing `test_proc_ops.py` tests verify the `Softmax` operator in isolation — they call it directly with a constructed `Tensor`. There was no test exercising the full chain:

1. `SoftmaxDescr` spec object (introduced in `bioimageio.spec` 0.5.9)  
2. `get_proc()` dispatch  
3. `Softmax` operator  
4. Numerical correctness as a probability distribution

A contributor who tried to package a multi-class segmentation model got confused because their environment had `bioimageio.spec 0.5.4.3` (which predates `SoftmaxDescr`), made them believe softmax postprocessing was unsupported, and ended up embedding softmax inside `model.forward()` as a workaround. See #485.

## Fix

Add `test_softmax_from_spec_descr` to `test_proc_ops.py`. It:
- Constructs a `SoftmaxDescr` and `OutputTensorDescr` via the spec API
- Calls `get_proc(softmax_descr, tensor_descr)` and asserts it returns `Softmax`
- Verifies the operator output matches `scipy.special.softmax`
- Checks that channel sums equal 1.0 (valid probability distribution)

This serves as both a regression guard and living documentation that `softmax` is a first-class postprocessing operation when `bioimageio.spec >= 0.5.9` is used.

Closes #485

cc @fynnbe