### PR TITLE
Fix release drafter by adding permission and auto publish on version bump

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,25 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+version-resolver:
+  major:
+    labels:
+      - 'breaking'
+  minor:
+    labels:
+      - 'enhancement'
+  patch:
+    labels:
+      - 'bug'
+      - 'performance'
+      - 'testing'
+      - 'ci'
+      - 'github_actions'
+      - 'documentation'
+      - 'refactoring'
+      - 'style'
+      - 'dependencies'
+      - 'build'
+  default: patch
 autolabeler:
   - label: "github_actions"
     files:

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -9,12 +9,43 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   update-release-draft:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v7
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check out the repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Detect new version
+        id: check-version
+        if: github.event_name == 'push'
+        uses: salsify/action-detect-and-tag-new-version@v2.0.1
+        with:
+          create-tag: false
+          version-command: |
+            grep -Eo '^__version__ = \"(.*)\"$' src/bioimageio/core/__init__.py | cut -d\" -f2
+
+      - name: Push tag
+        id: tag-version
+        if: github.event_name == 'push' && steps.check-version.outputs.previous-version != steps.check-version.outputs.current-version
+        uses: mathieudutour/github-tag-action@v6.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: ${{ steps.check-version.outputs.current-version }}
+
+      - name: Publish release notes
+        uses: release-drafter/release-drafter@v6.0.0
         with:
           commitish: main
+          publish: "${{ steps.tag-version.outputs.new_tag != '' }}"
+          tag: "${{ steps.tag-version.outputs.new_tag }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hi @FynnBe,

I think the drafter should be working now. It was previously missing `contents: write`, and `pull-requests: write` sort of permissions, so my best guess is this is one of the reasons why the action silently couldn't create or update release drafts.

Also, I noticed that `release-drafter.yml` was missing `name-template`, `tag-template`, and `version-resolver`, so the action had no way to name or version **releases.**

Now regarding the manual part: I tagged a version change detector, i.e. bumping `__version__` in `src/bioimageio/core/__init__.py` and merging to `main` now should in theory automatically tag the commit and publish the release draft. Maybe good to keep in mind that non-bumping merges would continue to accumulate the draft.

PS. Most of the ideas here are hacked up from our workflow in `micro-sam` for this ;)

I think this should be working, however can't test extensively at my end, unless the next rc is on-the-way!

Let me know how it looks! (and please feel free to take over and change things as you like)