### PR TITLE
Add micro-sam (μSAM) watershed postprocessing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ partners = [
     # "stardist",         # for model testing and stardist postprocessing  # TODO: add updated stardist to partners env
 ]
 stardist = ["stardist"] # for stardist postprocessing
+microsam = ["scikit-image"] # for micro-sam (μSAM) watershed postprocessing
 gradio-server = ['gradio[mcp];python_version>="3.10"']
 gradio-client = ['gradio_client;python_version>="3.10"']
 dev = [

--- a/src/bioimageio/core/__init__.py
+++ b/src/bioimageio/core/__init__.py
@@ -55,6 +55,7 @@ from . import stat_measures as stat_measures
 from . import tensor as tensor
 from . import weight_converters as weight_converters
 from ._prediction_pipeline import IntermediatePrediction as IntermediatePrediction
+from ._ops_microsam import microsam_watershed as microsam_watershed
 from ._prediction_pipeline import PredictionPipeline as PredictionPipeline
 from ._prediction_pipeline import RemotePredictionPipeline as RemotePredictionPipeline
 from ._prediction_pipeline import (

--- a/src/bioimageio/core/__init__.py
+++ b/src/bioimageio/core/__init__.py
@@ -55,7 +55,6 @@ from . import stat_measures as stat_measures
 from . import tensor as tensor
 from . import weight_converters as weight_converters
 from ._prediction_pipeline import IntermediatePrediction as IntermediatePrediction
-from ._ops_microsam import microsam_watershed as microsam_watershed
 from ._prediction_pipeline import PredictionPipeline as PredictionPipeline
 from ._prediction_pipeline import RemotePredictionPipeline as RemotePredictionPipeline
 from ._prediction_pipeline import (

--- a/src/bioimageio/core/_ops_microsam.py
+++ b/src/bioimageio/core/_ops_microsam.py
@@ -1,118 +1,139 @@
-"""micro-sam (μSAM) instance segmentation postprocessing.
-
-μSAM models with an additional instance segmentation (AIS) decoder predict
-three dense maps: foreground probability, center distance and boundary
-distance. Instance labels are obtained from these maps with a seeded
-watershed, as implemented in
-`micro_sam.instance_segmentation.InstanceSegmentationWithDecoder` /
-`torch_em.util.segmentation.watershed_from_center_and_boundary_distances`:
-
-- Anna Archit et al. [*Segment Anything for Microscopy*](https://www.nature.com/articles/s41592-024-02580-4).
-  Nature Methods, 2025.
-
-This module ports that postprocessing so that the packaged, prompt-free
-μSAM AIS models (which output the three maps) can be turned into instance
-segmentations by any tool building on bioimageio.core.
-
-Note: the watershed itself requires the `scikit-image` package
-(`pip install bioimageio.core[microsam]`).
-"""
-
-from typing import Optional
+from dataclasses import dataclass
+from typing import Any, Collection
 
 import numpy as np
 from numpy.typing import NDArray
 from scipy.ndimage import gaussian_filter
 from scipy.ndimage import label as connected_components
+from typing_extensions import Literal
+
+from bioimageio.spec.model.v0_5 import MicroSamWatershedDescr
+
+from ._op_base import SamplewiseOperator
+from .axis import AxisId, PerAxis
+from .common import MemberId
+from .sample import Sample
+from .stat_measures import Measure
+from .tensor import Tensor
 
 
-def microsam_watershed(
-    maps: Optional[NDArray[np.floating]] = None,
-    *,
-    foreground: Optional[NDArray[np.floating]] = None,
-    center_distances: Optional[NDArray[np.floating]] = None,
-    boundary_distances: Optional[NDArray[np.floating]] = None,
-    center_distance_threshold: float = 0.5,
-    boundary_distance_threshold: float = 0.5,
-    foreground_threshold: float = 0.5,
-    foreground_smoothing: float = 1.0,
-    distance_smoothing: float = 1.6,
-    min_size: int = 0,
-) -> NDArray[np.int64]:
-    """Compute an instance segmentation from μSAM AIS decoder predictions.
+@dataclass
+class MicroSamWatershed(SamplewiseOperator):
+    """micro-sam instance segmentation postprocessing operator.
 
-    Seeds are connected components where both (smoothed) distance predictions
-    are below their thresholds, intersected with the foreground mask. The
-    seeded watershed then runs on the smoothed boundary distances, restricted
-    to the foreground mask.
+    Replaces the three dense maps predicted by a micro-sam instance segmentation
+    (AIS) decoder -- foreground probability, center distance and inverted
+    boundary distance -- with instance labels (0 = background).
 
-    Args:
-        maps: The stacked decoder output with a leading channel axis of size 3
-            in the order (foreground, center_distances, boundary_distances),
-            i.e. shape (3, *spatial). Mutually exclusive with passing the
-            three maps individually.
-        foreground: Foreground probability prediction.
-        center_distances: Distance prediction to the object centers.
-        boundary_distances: Inverted distance prediction to object boundaries.
-        center_distance_threshold: Center distance predictions below this
-            value are used to find seeds.
-        boundary_distance_threshold: Boundary distance predictions below this
-            value are used to find seeds.
-        foreground_threshold: Foreground predictions above this value make up
-            the foreground mask.
-        foreground_smoothing: Sigma for gaussian smoothing of the foreground
-            prediction (avoids checkerboard artifacts). Set to 0 to disable.
-        distance_smoothing: Sigma for gaussian smoothing of both distance
-            predictions. Set to 0 to disable.
-        min_size: Minimal object size; smaller instances are removed.
+    Seeds are connected components where both smoothed distance predictions are
+    below their thresholds, intersected with the foreground mask; the seeded
+    watershed then runs on the smoothed boundary distances restricted to that
+    mask. This is a port of
+    `micro_sam.instance_segmentation.InstanceSegmentationWithDecoder` /
+    `torch_em.util.segmentation.watershed_from_center_and_boundary_distances`:
 
-    Returns:
-        The instance segmentation as an integer label image.
+    - Anna Archit et al. [*Segment Anything for Microscopy*](https://www.nature.com/articles/s41592-024-02580-4).
+      Nature Methods, 2025.
     """
-    try:
-        from skimage.segmentation import watershed
-    except ImportError as e:
-        raise ImportError(
-            "microsam_watershed requires the scikit-image package."
-            + " Install it e.g. via `pip install bioimageio.core[microsam]`."
-        ) from e
 
-    if maps is not None:
-        if foreground is not None or center_distances is not None or boundary_distances is not None:
-            raise ValueError(
-                "Pass either the stacked `maps` or the three individual maps, not both."
-            )
-        if maps.shape[0] != 3:
-            raise ValueError(
-                f"Expected a leading channel axis of size 3, got shape {maps.shape}."
-            )
-        foreground, center_distances, boundary_distances = maps
-    elif foreground is None or center_distances is None or boundary_distances is None:
-        raise ValueError(
-            "Pass either the stacked `maps` or all three of `foreground`,"
-            + " `center_distances` and `boundary_distances`."
+    center_distance_threshold: float = 0.5
+    boundary_distance_threshold: float = 0.5
+    foreground_threshold: float = 0.5
+    foreground_smoothing: float = 1.0
+    """Sigma of the gaussian smoothing applied to the foreground prediction. Set to 0 to disable smoothing."""
+    distance_smoothing: float = 1.6
+    """Sigma of the gaussian smoothing applied to both distance predictions. Set to 0 to disable smoothing."""
+    min_size: int = 0
+    """Minimum size of objects to keep, in pixels. Set to 0 to disable filtering by size."""
+    labels_id: MemberId = MemberId("labels")
+    output_dtype: Literal["uint16", "uint32"] = "uint16"
+
+    @classmethod
+    def from_proc_descr(
+        cls, proc_descr: MicroSamWatershedDescr, member_id: MemberId
+    ) -> "MicroSamWatershed":
+        kwargs = proc_descr.kwargs
+        return cls(
+            labels_id=member_id,
+            center_distance_threshold=kwargs.center_distance_threshold,
+            boundary_distance_threshold=kwargs.boundary_distance_threshold,
+            foreground_threshold=kwargs.foreground_threshold,
+            foreground_smoothing=kwargs.foreground_smoothing,
+            distance_smoothing=kwargs.distance_smoothing,
+            min_size=kwargs.min_size,
+            output_dtype=kwargs.output_dtype,
         )
 
-    if foreground_smoothing > 0:
-        foreground = gaussian_filter(foreground, foreground_smoothing)
-    if distance_smoothing > 0:
-        center_distances = gaussian_filter(center_distances, distance_smoothing)
-        boundary_distances = gaussian_filter(boundary_distances, distance_smoothing)
+    @property
+    def required_measures(self) -> Collection[Measure]:
+        return set()
 
-    fg_mask = foreground > foreground_threshold
-    marker_map = np.logical_and(
-        center_distances < center_distance_threshold,
-        boundary_distances < boundary_distance_threshold,
-    )
-    marker_map[~fg_mask] = False
-    markers, _ = connected_components(marker_map)
+    def get_output_shape(self, input_shape: PerAxis[int]) -> PerAxis[int]:
+        output_shape = dict(input_shape)
+        output_shape[AxisId("channel")] = 1
+        return output_shape
 
-    seg = watershed(boundary_distances, markers=markers, mask=fg_mask)
+    def __call__(self, sample: Sample) -> None:
+        input_tensor = sample.members[self.labels_id]
+        output_tensor = self._apply(input_tensor)
+        sample.members[self.labels_id] = output_tensor
 
-    if min_size > 0:
-        ids, sizes = np.unique(seg, return_counts=True)
-        too_small = ids[(sizes < min_size) & (ids != 0)]
-        if too_small.size:
-            seg[np.isin(seg, too_small)] = 0
+    def _apply(self, x: Tensor) -> Tensor:
+        if x.dims[0] != AxisId("batch"):
+            raise ValueError(
+                "Expected first axis to be 'batch' for micro-sam watershed."
+            )
 
-    return seg.astype(np.int64)
+        if x.dims[1] != AxisId("channel"):
+            raise ValueError(
+                "Expected second axis to be 'channel' with 3 channels for micro-sam watershed."
+            )
+        if x.shape[1] != 3:
+            raise ValueError(
+                "Expected 3 stacked tensors along the 'channel' axis: foreground,"
+                + " center_distances, boundary_distances for micro-sam watershed."
+            )
+
+        masks = [self._apply_impl(xx) for xx in x]
+        return Tensor.from_numpy(np.stack(masks, axis=0), dims=x.dims)
+
+    def _apply_impl(self, x: Tensor) -> NDArray[Any]:
+        """apply on a tensor without batch dimension"""
+        try:
+            from skimage.segmentation import (  # pyright: ignore[reportMissingTypeStubs]
+                watershed,  # pyright: ignore[reportUnknownVariableType]
+            )
+        except ImportError as e:
+            raise ImportError(
+                "scikit-image is required for microsam_watershed. Install with: pip install bioimageio.core[microsam]"
+            ) from e
+
+        foreground, center_distances, boundary_distances = x.to_numpy()
+
+        if self.foreground_smoothing > 0:
+            foreground = gaussian_filter(foreground, self.foreground_smoothing)
+        if self.distance_smoothing > 0:
+            center_distances = gaussian_filter(center_distances, self.distance_smoothing)
+            boundary_distances = gaussian_filter(
+                boundary_distances, self.distance_smoothing
+            )
+
+        fg_mask = foreground > self.foreground_threshold
+        marker_map = np.logical_and(
+            center_distances < self.center_distance_threshold,
+            boundary_distances < self.boundary_distance_threshold,
+        )
+        marker_map[~fg_mask] = False
+        markers, _ = connected_components(marker_map)
+
+        mask = np.asarray(watershed(boundary_distances, markers=markers, mask=fg_mask))
+
+        if self.min_size > 0:
+            ids, sizes = np.unique(mask, return_counts=True)
+            too_small = ids[(sizes < self.min_size) & (ids != 0)]
+            if too_small.size:
+                mask[np.isin(mask, too_small)] = 0
+
+        # add singleton channel axis for output to keep dims consistent with postprocessing input
+        mask = mask[None]
+        return mask.astype(np.dtype(self.output_dtype))

--- a/src/bioimageio/core/_ops_microsam.py
+++ b/src/bioimageio/core/_ops_microsam.py
@@ -1,0 +1,118 @@
+"""micro-sam (μSAM) instance segmentation postprocessing.
+
+μSAM models with an additional instance segmentation (AIS) decoder predict
+three dense maps: foreground probability, center distance and boundary
+distance. Instance labels are obtained from these maps with a seeded
+watershed, as implemented in
+`micro_sam.instance_segmentation.InstanceSegmentationWithDecoder` /
+`torch_em.util.segmentation.watershed_from_center_and_boundary_distances`:
+
+- Anna Archit et al. [*Segment Anything for Microscopy*](https://www.nature.com/articles/s41592-024-02580-4).
+  Nature Methods, 2025.
+
+This module ports that postprocessing so that the packaged, prompt-free
+μSAM AIS models (which output the three maps) can be turned into instance
+segmentations by any tool building on bioimageio.core.
+
+Note: the watershed itself requires the `scikit-image` package
+(`pip install bioimageio.core[microsam]`).
+"""
+
+from typing import Optional
+
+import numpy as np
+from numpy.typing import NDArray
+from scipy.ndimage import gaussian_filter
+from scipy.ndimage import label as connected_components
+
+
+def microsam_watershed(
+    maps: Optional[NDArray[np.floating]] = None,
+    *,
+    foreground: Optional[NDArray[np.floating]] = None,
+    center_distances: Optional[NDArray[np.floating]] = None,
+    boundary_distances: Optional[NDArray[np.floating]] = None,
+    center_distance_threshold: float = 0.5,
+    boundary_distance_threshold: float = 0.5,
+    foreground_threshold: float = 0.5,
+    foreground_smoothing: float = 1.0,
+    distance_smoothing: float = 1.6,
+    min_size: int = 0,
+) -> NDArray[np.int64]:
+    """Compute an instance segmentation from μSAM AIS decoder predictions.
+
+    Seeds are connected components where both (smoothed) distance predictions
+    are below their thresholds, intersected with the foreground mask. The
+    seeded watershed then runs on the smoothed boundary distances, restricted
+    to the foreground mask.
+
+    Args:
+        maps: The stacked decoder output with a leading channel axis of size 3
+            in the order (foreground, center_distances, boundary_distances),
+            i.e. shape (3, *spatial). Mutually exclusive with passing the
+            three maps individually.
+        foreground: Foreground probability prediction.
+        center_distances: Distance prediction to the object centers.
+        boundary_distances: Inverted distance prediction to object boundaries.
+        center_distance_threshold: Center distance predictions below this
+            value are used to find seeds.
+        boundary_distance_threshold: Boundary distance predictions below this
+            value are used to find seeds.
+        foreground_threshold: Foreground predictions above this value make up
+            the foreground mask.
+        foreground_smoothing: Sigma for gaussian smoothing of the foreground
+            prediction (avoids checkerboard artifacts). Set to 0 to disable.
+        distance_smoothing: Sigma for gaussian smoothing of both distance
+            predictions. Set to 0 to disable.
+        min_size: Minimal object size; smaller instances are removed.
+
+    Returns:
+        The instance segmentation as an integer label image.
+    """
+    try:
+        from skimage.segmentation import watershed
+    except ImportError as e:
+        raise ImportError(
+            "microsam_watershed requires the scikit-image package."
+            + " Install it e.g. via `pip install bioimageio.core[microsam]`."
+        ) from e
+
+    if maps is not None:
+        if foreground is not None or center_distances is not None or boundary_distances is not None:
+            raise ValueError(
+                "Pass either the stacked `maps` or the three individual maps, not both."
+            )
+        if maps.shape[0] != 3:
+            raise ValueError(
+                f"Expected a leading channel axis of size 3, got shape {maps.shape}."
+            )
+        foreground, center_distances, boundary_distances = maps
+    elif foreground is None or center_distances is None or boundary_distances is None:
+        raise ValueError(
+            "Pass either the stacked `maps` or all three of `foreground`,"
+            + " `center_distances` and `boundary_distances`."
+        )
+
+    if foreground_smoothing > 0:
+        foreground = gaussian_filter(foreground, foreground_smoothing)
+    if distance_smoothing > 0:
+        center_distances = gaussian_filter(center_distances, distance_smoothing)
+        boundary_distances = gaussian_filter(boundary_distances, distance_smoothing)
+
+    fg_mask = foreground > foreground_threshold
+    marker_map = np.logical_and(
+        center_distances < center_distance_threshold,
+        boundary_distances < boundary_distance_threshold,
+    )
+    marker_map[~fg_mask] = False
+    markers, _ = connected_components(marker_map)
+
+    seg = watershed(boundary_distances, markers=markers, mask=fg_mask)
+
+    if min_size > 0:
+        ids, sizes = np.unique(seg, return_counts=True)
+        too_small = ids[(sizes < min_size) & (ids != 0)]
+        if too_small.size:
+            seg[np.isin(seg, too_small)] = 0
+
+    return seg.astype(np.int64)

--- a/src/bioimageio/core/proc_ops.py
+++ b/src/bioimageio/core/proc_ops.py
@@ -27,6 +27,7 @@ from bioimageio.spec.model.v0_5 import (
 
 from ._op_base import BlockwiseOperator, SamplewiseOperator, SimpleOperator
 from ._ops_cellpose import CellposeFlowDynamics
+from ._ops_microsam import MicroSamWatershed
 from ._ops_stardist import StardistPostprocessing2D as StardistPostprocessing2D
 from ._ops_stardist import StardistPostprocessing3D as StardistPostprocessing3D
 from .axis import AxisId
@@ -828,6 +829,7 @@ Processing = Union[
     CustomProcessing,
     EnsureDtype,
     FixedZeroMeanUnitVariance,
+    MicroSamWatershed,
     ScaleLinear,
     ScaleMeanVariance,
     ScaleRange,
@@ -863,6 +865,8 @@ def get_proc(
         return EnsureDtype.from_proc_descr(proc_descr, member_id)
     elif isinstance(proc_descr, v0_5.FixedZeroMeanUnitVarianceDescr):
         return FixedZeroMeanUnitVariance.from_proc_descr(proc_descr, member_id)
+    elif isinstance(proc_descr, v0_5.MicroSamWatershedDescr):
+        return MicroSamWatershed.from_proc_descr(proc_descr, member_id)
     elif isinstance(proc_descr, (v0_4.ScaleLinearDescr, v0_5.ScaleLinearDescr)):
         return ScaleLinear.from_proc_descr(proc_descr, member_id)
     elif isinstance(

--- a/tests/test_ops_microsam.py
+++ b/tests/test_ops_microsam.py
@@ -1,0 +1,72 @@
+import numpy as np
+import pytest
+
+pytest.importorskip("skimage")
+
+from bioimageio.core import microsam_watershed
+
+
+def _two_cell_maps(shape=(64, 64)):
+    """Synthetic AIS decoder maps for two round cells."""
+    h, w = shape
+    yy, xx = np.mgrid[0:h, 0:w]
+    centers = [(16, 16), (16, 48)]
+    radius = 16.0
+
+    foreground = np.zeros(shape, dtype="float32")
+    center_distances = np.ones(shape, dtype="float32")
+    for cy, cx in centers:
+        d = np.sqrt((yy - cy) ** 2 + (xx - cx) ** 2)
+        foreground = np.maximum(foreground, (d < radius).astype("float32"))
+        center_distances = np.minimum(center_distances, np.clip(d / radius, 0, 1))
+    # inverted boundary distance: low deep inside the cells, high toward the
+    # rim, with an explicit ridge at the touching border
+    boundary_distances = center_distances.copy()
+    boundary_distances[:, 31:33] = 1.0
+    return np.stack([foreground, center_distances, boundary_distances])
+
+
+def test_two_instances_from_stacked_maps():
+    maps = _two_cell_maps()
+    seg = microsam_watershed(maps)
+    ids = set(np.unique(seg)) - {0}
+    assert len(ids) == 2
+    # instances are separated left/right
+    assert seg[16, 16] != seg[16, 48]
+    assert seg[16, 16] != 0 and seg[16, 48] != 0
+    # background stays background
+    assert seg[60, 32] == 0
+
+
+def test_individual_maps_match_stacked():
+    maps = _two_cell_maps()
+    seg_stacked = microsam_watershed(maps)
+    seg_individual = microsam_watershed(
+        foreground=maps[0], center_distances=maps[1], boundary_distances=maps[2]
+    )
+    assert np.array_equal(seg_stacked, seg_individual)
+
+
+def test_min_size_filters_small_instances():
+    maps = _two_cell_maps()
+    # add a tiny speck
+    maps[0, 58:62, 58:62] = 1.0
+    maps[1, 58:62, 58:62] = 0.0
+    maps[2, 58:62, 58:62] = 0.0
+    seg_all = microsam_watershed(maps, foreground_smoothing=0, distance_smoothing=0)
+    seg_filtered = microsam_watershed(
+        maps, foreground_smoothing=0, distance_smoothing=0, min_size=50
+    )
+    assert len(set(np.unique(seg_all)) - {0}) == 3
+    assert len(set(np.unique(seg_filtered)) - {0}) == 2
+    assert (seg_filtered[58:62, 58:62] == 0).all()
+
+
+def test_input_validation():
+    maps = _two_cell_maps()
+    with pytest.raises(ValueError, match="not both"):
+        microsam_watershed(maps, foreground=maps[0])
+    with pytest.raises(ValueError, match="channel axis of size 3"):
+        microsam_watershed(maps[:2])
+    with pytest.raises(ValueError, match="all three"):
+        microsam_watershed(foreground=maps[0], center_distances=maps[1])

--- a/tests/test_ops_microsam.py
+++ b/tests/test_ops_microsam.py
@@ -1,13 +1,22 @@
 import numpy as np
 import pytest
+from numpy.typing import NDArray
 
 pytest.importorskip("skimage")
 
-from bioimageio.core import microsam_watershed
+from bioimageio.core.axis import AxisId
+from bioimageio.core.common import MemberId
+from bioimageio.core.sample import Sample
+from bioimageio.core.tensor import Tensor
 
 
-def _two_cell_maps(shape=(64, 64)):
-    """Synthetic AIS decoder maps for two round cells."""
+@pytest.fixture(scope="module")
+def tid():
+    return MemberId("labels")
+
+
+def _two_cell_maps(shape: "tuple[int, int]" = (64, 64)) -> NDArray[np.float32]:
+    """Synthetic AIS decoder maps for two round cells, as (batch, channel, y, x)."""
     h, w = shape
     yy, xx = np.mgrid[0:h, 0:w]
     centers = [(16, 16), (16, 48)]
@@ -19,54 +28,76 @@ def _two_cell_maps(shape=(64, 64)):
         d = np.sqrt((yy - cy) ** 2 + (xx - cx) ** 2)
         foreground = np.maximum(foreground, (d < radius).astype("float32"))
         center_distances = np.minimum(center_distances, np.clip(d / radius, 0, 1))
+
     # inverted boundary distance: low deep inside the cells, high toward the
     # rim, with an explicit ridge at the touching border
     boundary_distances = center_distances.copy()
     boundary_distances[:, 31:33] = 1.0
-    return np.stack([foreground, center_distances, boundary_distances])
+    return np.stack([foreground, center_distances, boundary_distances])[None]
 
 
-def test_two_instances_from_stacked_maps():
-    maps = _two_cell_maps()
-    seg = microsam_watershed(maps)
-    ids = set(np.unique(seg)) - {0}
+def _segment(tid: MemberId, maps: NDArray[np.float32], **kwargs: object) -> NDArray[np.uint16]:
+    from bioimageio.core.proc_ops import MicroSamWatershed
+
+    sample = Sample(
+        members={
+            tid: Tensor.from_numpy(maps, dims=[AxisId(a) for a in ("batch", "channel", "y", "x")])
+        },
+        stat={},
+        id=None,
+    )
+    MicroSamWatershed(labels_id=tid, **kwargs)(sample)  # pyright: ignore[reportArgumentType]
+    return sample.members[tid].to_numpy()
+
+
+def test_two_instances(tid: MemberId):
+    seg = _segment(tid, _two_cell_maps())
+    assert seg.shape == (1, 1, 64, 64)
+    assert seg.dtype == np.uint16
+
+    labels = seg[0, 0]
+    ids = set(np.unique(labels)) - {0}
     assert len(ids) == 2
     # instances are separated left/right
-    assert seg[16, 16] != seg[16, 48]
-    assert seg[16, 16] != 0 and seg[16, 48] != 0
+    assert labels[16, 16] != labels[16, 48]
+    assert labels[16, 16] != 0 and labels[16, 48] != 0
     # background stays background
-    assert seg[60, 32] == 0
+    assert labels[60, 32] == 0
 
 
-def test_individual_maps_match_stacked():
-    maps = _two_cell_maps()
-    seg_stacked = microsam_watershed(maps)
-    seg_individual = microsam_watershed(
-        foreground=maps[0], center_distances=maps[1], boundary_distances=maps[2]
-    )
-    assert np.array_equal(seg_stacked, seg_individual)
-
-
-def test_min_size_filters_small_instances():
+def test_min_size_filters_small_instances(tid: MemberId):
     maps = _two_cell_maps()
     # add a tiny speck
-    maps[0, 58:62, 58:62] = 1.0
-    maps[1, 58:62, 58:62] = 0.0
-    maps[2, 58:62, 58:62] = 0.0
-    seg_all = microsam_watershed(maps, foreground_smoothing=0, distance_smoothing=0)
-    seg_filtered = microsam_watershed(
-        maps, foreground_smoothing=0, distance_smoothing=0, min_size=50
+    maps[0, 0, 58:62, 58:62] = 1.0
+    maps[0, 1, 58:62, 58:62] = 0.0
+    maps[0, 2, 58:62, 58:62] = 0.0
+
+    unfiltered = _segment(tid, maps, foreground_smoothing=0, distance_smoothing=0)
+    filtered = _segment(
+        tid, maps, foreground_smoothing=0, distance_smoothing=0, min_size=50
     )
-    assert len(set(np.unique(seg_all)) - {0}) == 3
-    assert len(set(np.unique(seg_filtered)) - {0}) == 2
-    assert (seg_filtered[58:62, 58:62] == 0).all()
+    assert len(set(np.unique(unfiltered)) - {0}) == 3
+    assert len(set(np.unique(filtered)) - {0}) == 2
+    assert (filtered[0, 0, 58:62, 58:62] == 0).all()
 
 
-def test_input_validation():
-    maps = _two_cell_maps()
-    with pytest.raises(ValueError, match="not both"):
-        microsam_watershed(maps, foreground=maps[0])
-    with pytest.raises(ValueError, match="channel axis of size 3"):
-        microsam_watershed(maps[:2])
-    with pytest.raises(ValueError, match="all three"):
-        microsam_watershed(foreground=maps[0], center_distances=maps[1])
+def test_from_proc_descr(tid: MemberId):
+    from bioimageio.spec.model.v0_5 import MicroSamWatershedDescr, MicroSamWatershedKwargs
+
+    from bioimageio.core.proc_ops import MicroSamWatershed
+
+    op = MicroSamWatershed.from_proc_descr(
+        MicroSamWatershedDescr(
+            kwargs=MicroSamWatershedKwargs(min_size=25, output_dtype="uint32")
+        ),
+        tid,
+    )
+    assert op.labels_id == tid
+    assert op.min_size == 25
+    assert op.output_dtype == "uint32"
+    assert op.distance_smoothing == 1.6
+
+
+def test_rejects_wrong_channel_count(tid: MemberId):
+    with pytest.raises(ValueError, match="3 stacked tensors"):
+        _ = _segment(tid, _two_cell_maps()[:, :2])


### PR DESCRIPTION
## Motivation

micro-sam models with the additional instance segmentation (AIS) decoder predict three dense maps (foreground probability, center distance, inverted boundary distance). Exported as bioimageio packages, such models run a plain prompt-free prediction pass, but turning the maps into instance labels requires micro-sam's seeded watershed, which so far only exists inside the `micro_sam` package. This PR makes that final step available to any tool building on `bioimageio.core`, following the precedent of the stardist and cellpose postprocessing already in this repo.

## What is added

- `MicroSamWatershed`, a `SamplewiseOperator` that replaces the three stacked decoder maps on its sample member with instance labels. Seeds are connected components where both smoothed distance maps are below their thresholds inside the foreground mask; the seeded watershed runs on the smoothed boundary distances restricted to that mask. Faithful port of `micro_sam.instance_segmentation.InstanceSegmentationWithDecoder` / `torch_em.util.segmentation.watershed_from_center_and_boundary_distances`, with the upstream parameter defaults (thresholds 0.5, foreground smoothing 1.0, distance smoothing 1.6, `min_size` 0).
- `from_proc_descr(MicroSamWatershedDescr, member_id)` plus registration in `proc_ops` — import, `Processing` union, and a `get_proc` dispatch branch — mirroring `CellposeFlowDynamics`.
- Optional extra `bioimageio.core[microsam]` providing `scikit-image` (only needed for the watershed itself; gaussian smoothing and connected components use the existing scipy dependency), mirroring the `stardist` extra. scikit-image is imported lazily so the module stays importable without it.
- Unit tests with synthetic two-cell maps: instance separation across a boundary ridge, `min_size` filtering, channel-count validation, and `from_proc_descr` kwargs mapping.

## Depends on bioimage-io/spec-bioimage-io#768

`from_proc_descr` binds to `MicroSamWatershedDescr`, which that PR adds to `bioimageio.spec.model.v0_5`. Until it is released, the `bioimageio.spec ==0.5.12.0` pin here does not contain the descriptor and CI cannot pass; the pin needs bumping to whichever release carries it. Verified locally against a co-developed spec checkout (`extraPaths = ["../spec-bioimage-io/src"]`).

## Test plan

- `pytest tests/test_ops_microsam.py` — 4 passed, against the spec branch of #768.
- `get_proc` dispatch checked end to end: an `OutputTensorDescr` carrying a `MicroSamWatershedDescr` postprocessing entry resolves to a `MicroSamWatershed` with the declared kwargs and the tensor's member id.
- Behavior cross-checked against the micro_sam / torch_em source and the parameter defaults used by the micro-sam BioEngine deployment.
